### PR TITLE
Fix linker -Wl option; add python library for linker

### DIFF
--- a/tools/cxx/libs.py
+++ b/tools/cxx/libs.py
@@ -3,7 +3,8 @@
 def getlibs(extdir, makeFlags):
  flags=''
  pythonLibPaths=[ p for p in makeFlags['PYBIND11LIBS'].split() if p.startswith('-L') ]
- for p in pythonLibPaths: flags += ' -Wl,-rpath,' + p.replace('-L', '') + ' '  
- flags+='-L' + extdir + ' -lkorali -Wl,-rpath -Wl,' + extdir + ' '
- flags+='-L' + makeFlags['GSLPREFIX'] + '/lib -Wl,-rpath -Wl,' + makeFlags['GSLPREFIX'] + '/lib ' 
+ for p in pythonLibPaths: flags += ' -Wl,-rpath,' + p.replace('-L', '') + ' '
+ flags+='-L' + extdir + ' -lkorali -Wl,-rpath,' + extdir + ' '
+ flags+='-L' + makeFlags['GSLPREFIX'] + '/lib -Wl,-rpath,' + makeFlags['GSLPREFIX'] + '/lib '
+ flags+='-lpython3'
  print(flags + ' ' + makeFlags['GSLLIBS'] + ' ' + makeFlags['PYBIND11LIBS'])


### PR DESCRIPTION
The combination

-Wl,-rpath -Wl,<path>

does not work correctly when using korali as a library where linker
flags are obtained with

python3 -m korali.cxx --libs

CMake applies permutations to the string and violates the sequential
order requirement of the linker options above.  The options are changed
to:

-Wl,-rpath,<path>

The -lpython3 library is also missing at link time (this assumes the
environment is setup correctly and the linker is able to find the right
python library to link against)