### PR TITLE
Increasing the stack size of coroutines

### DIFF
--- a/source/modules/conduit/conduit._cpp
+++ b/source/modules/conduit/conduit._cpp
@@ -26,7 +26,7 @@ void korali::Conduit::initiateSample(knlohmann::json &sampleJs)
     sampleJs["Finished"] = false;
     sampleJs["Globals"] = _globals;
     experiment->sampleIdMap[sampleId] = new korali::Sample;
-    experiment->sampleIdMap[sampleId]->_sampleThread = co_create(8192 * sizeof(void *), korali::Sample::sampleLauncher);
+    experiment->sampleIdMap[sampleId]->_sampleThread = co_create(1 << 30, korali::Sample::sampleLauncher);
   }
 
   experiment->sampleIdMap[sampleId]->_js.getJson() = sampleJs;
@@ -69,7 +69,7 @@ void korali::Conduit::start(korali::Sample &sample)
   if (sample._state != SampleState::uninitialized) _logger->logError("Sample has already been initialized.\n");
 
   if (sample._isAllocated == false)
-    sample._sampleThread = co_create(8192 * sizeof(void *), korali::Conduit::coroutineWrapper);
+    sample._sampleThread = co_create(1 < 24, korali::Conduit::coroutineWrapper);
   else
     _logger->logError("Sample thread is already allocated; has it executed before being re-started?\n");
 

--- a/source/modules/conduit/conduit._cpp
+++ b/source/modules/conduit/conduit._cpp
@@ -69,7 +69,7 @@ void korali::Conduit::start(korali::Sample &sample)
   if (sample._state != SampleState::uninitialized) _logger->logError("Sample has already been initialized.\n");
 
   if (sample._isAllocated == false)
-    sample._sampleThread = co_create(1 < 24, korali::Conduit::coroutineWrapper);
+    sample._sampleThread = co_create(1 << 24, korali::Conduit::coroutineWrapper);
   else
     _logger->logError("Sample thread is already allocated; has it executed before being re-started?\n");
 


### PR DESCRIPTION
To prevent stack overflows when computing a sample. This does not affect mem usage, unless the pages are accessed.