### PR TITLE
Fix a trailing null byte in a string split in TMCMC plotter

### DIFF
--- a/source/modules/solver/TMCMC/TMCMC.py
+++ b/source/modules/solver/TMCMC/TMCMC.py
@@ -98,7 +98,7 @@ def plot(genList):
     fig, ax = plt.subplots(numdim, numdim, figsize=(8,8))
     samplesTmp = np.reshape( samples, (numentries,numdim) )
     version = genList[lastGen]['Solver']['Version']
-    plt.suptitle( '{0} Plotter - \nNumber of Samples {1}\n'.format(str(version), str(numentries)), fontweight='bold', fontsize  = 12)
+    plt.suptitle( '{0} Plotter - \nNumber of Samples {1}'.format(str(version), str(numentries)).strip(), fontweight='bold', fontsize  = 12)
     
 
     plot_histogram(ax, samplesTmp)


### PR DESCRIPTION
The trailing \n character in the title string causes a b'' string when
the title is split.  This causes dvipng to fail if the
matplotlib.rcParams['text.usetex'] = True flag is used for plotting with
LaTeX rendered fonts.