### PR TITLE
conduit/conduit._cpp:  increase stack size in Conduit::start

### DIFF
--- a/source/modules/conduit/conduit._cpp
+++ b/source/modules/conduit/conduit._cpp
@@ -76,7 +76,7 @@ void Conduit::start(Sample &sample)
   if (sample._state != SampleState::uninitialized) KORALI_LOG_ERROR("Sample has already been initialized.\n");
 
   if (sample._isAllocated == false)
-    sample._sampleThread = co_create(1 << 24, Conduit::coroutineWrapper);
+    sample._sampleThread = co_create(1 << 28, Conduit::coroutineWrapper);
   else
     KORALI_LOG_ERROR("Sample thread is already allocated; has it executed before being re-started?\n");
 


### PR DESCRIPTION
increase from `1 << 24` to `1 << 28`,
workaround for freezing on the propagation stage of `korali-apps/covid19`