### PR TITLE
Nested.py: remove trailing '\n' in plt.suptitle()

### DIFF
--- a/source/modules/solver/sampler/Nested/Nested.py
+++ b/source/modules/solver/sampler/Nested/Nested.py
@@ -125,7 +125,7 @@ def plotGen(genList, idx):
   fig, ax = plt.subplots(numdim, numdim, figsize=(8, 8))
   samplesTmp = np.reshape(samples, (numentries, numdim))
   plt.suptitle(
-      'Nested Plotter - \nNumber of Samples {0}\n'.format(str(numentries)),
+      'Nested Plotter - \nNumber of Samples {0}'.format(str(numentries)),
       fontweight='bold',
       fontsize=12)
   plot_histogram(ax, samplesTmp)


### PR DESCRIPTION
fixes error with enabled latex ('text.usetex:True' in matplotlibrc):

```
RuntimeError: dvipng was not able to process the following string:
b''
```