### PR TITLE
Implementing smarties-type optimizations to the retrace function

### DIFF
--- a/examples/features/checkpoint.resume/run-gfpt.py
+++ b/examples/features/checkpoint.resume/run-gfpt.py
@@ -57,7 +57,6 @@ e["Solver"]["Type"] = "Agent / Continuous / GFPT"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 1
-e["Solver"]["Cache Persistence"] = 10
 e["Solver"]["Discount Factor"] = 0.99
 
 ### Defining the configuration of replay memory

--- a/examples/features/checkpoint.resume/run-gfpt.py
+++ b/examples/features/checkpoint.resume/run-gfpt.py
@@ -32,7 +32,7 @@ if (found == True):
 
 e["Problem"]["Type"] = "Reinforcement Learning / Continuous"
 e["Problem"]["Environment Function"] = env
-e["Problem"]["Actions Between Policy Updates"] = 1
+e["Problem"]["Actions Between Policy Updates"] = 500
 e["Problem"]["Training Reward Threshold"] = 450
 e["Problem"]["Policy Testing Episodes"] = 10
 
@@ -49,14 +49,14 @@ e["Variables"][4]["Name"] = "Force"
 e["Variables"][4]["Type"] = "Action"
 e["Variables"][4]["Lower Bound"] = -10.0
 e["Variables"][4]["Upper Bound"] = +10.0
-e["Variables"][4]["Initial Exploration Noise"] = 2.0
+e["Variables"][4]["Initial Exploration Noise"] = 1.0
 
 ### Defining Agent Configuration 
 
 e["Solver"]["Type"] = "Agent / Continuous / GFPT"
 e["Solver"]["Mode"] = "Training"
-e["Solver"]["Episodes Per Generation"] = 1
-e["Solver"]["Experiences Between Policy Updates"] = 1
+e["Solver"]["Episodes Per Generation"] = 10
+e["Solver"]["Experiences Between Policy Updates"] = 10
 e["Solver"]["Discount Factor"] = 0.99
 
 ### Defining the configuration of replay memory
@@ -66,16 +66,20 @@ e["Solver"]["Mini Batch Strategy"] = "Uniform"
 e["Solver"]["Experience Replay"]["Start Size"] =   1024
 e["Solver"]["Experience Replay"]["Maximum Size"] = 32768
 
+### Configuring the Remember-and-Forget Experience Replay algorithm
+
+e["Solver"]["Experience Replay"]["Off Policy"]["Cutoff Scale"] = 4.0
+e["Solver"]["Experience Replay"]["Off Policy"]["Target"] = 0.1
+e["Solver"]["Experience Replay"]["Off Policy"]["Annealing Rate"] = 5e-7
+e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
+
 ## Defining Critic and Policy Configuration
 
-e["Solver"]["Learning Rate"] = 0.01
-e["Solver"]["Policy"]["Learning Rate Scale"] = 1.0
-e["Solver"]["Policy"]["Target Accuracy"] = 0.01
-e["Solver"]["Policy"]["Optimization Candidates"] = 32
+e["Solver"]["Learning Rate"] = 0.0001
+e["Solver"]["Policy"]["Target Accuracy"] = 0.000001 
+e["Solver"]["Policy"]["Optimization Candidates"] = 64
 
 ### Configuring the neural network and its hidden layers
-
-e["Solver"]["Time Sequence Length"] = 1
 
 e["Solver"]["Neural Network"]["Engine"] = "OneDNN"
 
@@ -105,4 +109,3 @@ e["File Output"]["Frequency"] = 1
 ### Running Training Experiment
 
 k.run(e)
-

--- a/examples/learning/reinforcement/ABF2D/run-ddpg.py
+++ b/examples/learning/reinforcement/ABF2D/run-ddpg.py
@@ -2,38 +2,60 @@
 import os
 import sys
 import argparse
-sys.path.append('_model')
-from agent import *
-
-####### Parsing arguments
-
-parser = argparse.ArgumentParser()
-parser.add_argument('--env', help='Specifies which environment to run.', required=True)
-args = parser.parse_args()
-
-####### Defining Korali Problem
+sys.path.append('./_model')
+from env import *
 
 import korali
 k = korali.Engine()
 e = korali.Experiment()
 
-### Defining results folder and loading previous results, if any
+### Setting results dir for ABF2D trajectories
+ 
+setResultsDir('_result_ddpg')
 
-resultFolder = '_result_gfpt/' 
-e.loadState(resultFolder + '/latest');
+### Defining Korali Problem
 
-### Initializing openAI Gym environment
+e["Problem"]["Type"] = "Reinforcement Learning / Continuous"
+e["Problem"]["Environment Function"] = env
+e["Problem"]["Training Reward Threshold"] = 50.0
+e["Problem"]["Policy Testing Episodes"] = 1
+e["Problem"]["Actions Between Policy Updates"] = 200
 
-initEnvironment(e, args.env)
+### Defining state variables
+
+e["Variables"][0]["Name"] = "Swimmer 1 - Pos X"
+e["Variables"][1]["Name"] = "Swimmer 1 - Pos Y"
+e["Variables"][2]["Name"] = "Swimmer 2 - Pos X"
+e["Variables"][3]["Name"] = "Swimmer 2 - Pos Y"
+
+### Defining action variables
+
+e["Variables"][4]["Name"] = "Magnet Rotation X"
+e["Variables"][4]["Type"] = "Action"
+e["Variables"][4]["Lower Bound"] = -1.0
+e["Variables"][4]["Upper Bound"] = +1.0
+e["Variables"][4]["Initial Exploration Noise"] = 0.25
+
+e["Variables"][5]["Name"] = "Magnet Rotation Y"
+e["Variables"][5]["Type"] = "Action"
+e["Variables"][5]["Lower Bound"] = -1.0
+e["Variables"][5]["Upper Bound"] = +1.0
+e["Variables"][5]["Initial Exploration Noise"] = 0.25
+
+e["Variables"][6]["Name"] = "Magnet Intensity"
+e["Variables"][6]["Type"] = "Action"
+e["Variables"][6]["Lower Bound"] = +0.0
+e["Variables"][6]["Upper Bound"] = +2.0
+e["Variables"][6]["Initial Exploration Noise"] = 0.25
 
 ### Defining Agent Configuration 
 
-e["Solver"]["Type"] = "Agent / Continuous / GFPT"
+e["Solver"]["Type"] = "Agent / Continuous / DDPG"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 1
-e["Solver"]["Discount Factor"] = 0.995
-e["Solver"]["Learning Rate"] = 0.001
+e["Solver"]["Learning Rate"] = 1e-3
+e["Solver"]["Policy"]["Adoption Rate"] = 1.0
 
 ### Defining the configuration of replay memory
 
@@ -52,11 +74,6 @@ e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
 e["Solver"]["Mini Batch Size"] = 128
 e["Solver"]["Mini Batch Strategy"] = "Uniform"
 
-## Defining Critic and Policy Configuration
-
-e["Solver"]["Policy"]["Target Accuracy"] = 0.000001
-e["Solver"]["Policy"]["Optimization Candidates"] = 64
-
 ### Configuring the neural network and its hidden layers
 
 e["Solver"]["Neural Network"]["Engine"] = "OneDNN"
@@ -73,16 +90,18 @@ e["Solver"]["Neural Network"]["Hidden Layers"][2]["Output Channels"] = 64
 e["Solver"]["Neural Network"]["Hidden Layers"][3]["Type"] = "Layer/Activation"
 e["Solver"]["Neural Network"]["Hidden Layers"][3]["Function"] = "Elementwise/Tanh"
 
+### Defining Termination Criteria
+
+e["Solver"]["Termination Criteria"]["Testing"]["Target Average Reward"] = 50.0
+
 ### Setting console/file output configuration
 
-e["Solver"]["Termination Criteria"]["Max Generations"] = 100000
-e["Solver"]["Experience Replay"]["Serialize"] = True
+e["Solver"]["Experience Replay"]["Serialize"] = False
 e["Console Output"]["Verbosity"] = "Detailed"
 e["File Output"]["Enabled"] = True
-e["File Output"]["Frequency"] = 5
-e["File Output"]["Path"] = resultFolder
+e["File Output"]["Frequency"] = 1
+e["File Output"]["Path"] = "_result_ddpg"
 
 ### Running Experiment
 
 k.run(e)
-

--- a/examples/learning/reinforcement/ABF2D/run-gfpt.py
+++ b/examples/learning/reinforcement/ABF2D/run-gfpt.py
@@ -58,19 +58,25 @@ e["Solver"]["Learning Rate"] = 1e-4
 
 ### Defining the configuration of replay memory
 
-e["Solver"]["Experience Replay"]["Start Size"] = 65536
-e["Solver"]["Experience Replay"]["Maximum Size"] = 2*65536
+e["Solver"]["Experience Replay"]["Start Size"] = 4096
+e["Solver"]["Experience Replay"]["Maximum Size"] = 65536
+
+### Configuring the Remember-and-Forget Experience Replay algorithm
+
+e["Solver"]["Experience Replay"]["Off Policy"]["Cutoff Scale"] = 4.0
+e["Solver"]["Experience Replay"]["Off Policy"]["Target"] = 0.1
+e["Solver"]["Experience Replay"]["Off Policy"]["Annealing Rate"] = 5e-7
+e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
 
 ### Configuring Mini Batch
 
-e["Solver"]["Mini Batch Size"] = 32
+e["Solver"]["Mini Batch Size"] = 128
 e["Solver"]["Mini Batch Strategy"] = "Uniform"
 
 ## Defining Critic and Policy Configuration
 
-e["Solver"]["Policy"]["Learning Rate Scale"] = 1.0
-e["Solver"]["Policy"]["Target Accuracy"] = 0.001
-e["Solver"]["Policy"]["Optimization Candidates"] = 32
+e["Solver"]["Policy"]["Target Accuracy"] = 0.000001
+e["Solver"]["Policy"]["Optimization Candidates"] = 64 
 
 ### Configuring the neural network and its hidden layers
 

--- a/examples/learning/reinforcement/ABF2D/run-gfpt.py
+++ b/examples/learning/reinforcement/ABF2D/run-gfpt.py
@@ -54,7 +54,6 @@ e["Solver"]["Type"] = "Agent / Continuous / GFPT"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 1
-e["Solver"]["Cache Persistence"] = 100
 e["Solver"]["Learning Rate"] = 1e-4
 
 ### Defining the configuration of replay memory

--- a/examples/learning/reinforcement/ABF2D/run-vracer.py
+++ b/examples/learning/reinforcement/ABF2D/run-vracer.py
@@ -53,7 +53,6 @@ e["Variables"][6]["Initial Exploration Noise"] = 0.25
 e["Solver"]["Type"] = "Agent / Continuous / VRACER"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Experiences Between Policy Updates"] = 1
-e["Solver"]["Cache Persistence"] = 250
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Policy Distribution"] = "Normal"
 e["Solver"]["Discount Factor"] = 0.99
@@ -94,7 +93,7 @@ e["Solver"]["Termination Criteria"]["Testing"]["Target Average Reward"] = 50.0
 
 ### Setting file output configuration
 
-e["Solver"]["Experience Replay"]["Serialize"] = False
+e["Solver"]["Experience Replay"]["Serialize"] = True
 e["Console Output"]["Verbosity"] = "Detailed"
 e["File Output"]["Enabled"] = True
 e["File Output"]["Frequency"] = 10

--- a/examples/learning/reinforcement/cartpole/run-ddpg.py
+++ b/examples/learning/reinforcement/cartpole/run-ddpg.py
@@ -2,7 +2,7 @@
 import os
 import sys
 sys.path.append('./_model')
-from single_env import *
+from env import *
 
 ####### Defining Korali Problem
 
@@ -10,37 +10,47 @@ import korali
 k = korali.Engine()
 e = korali.Experiment()
 
-### Defining the Pendulum problem's configuration
+### Defining the Cartpole problem's configuration
 
 e["Problem"]["Type"] = "Reinforcement Learning / Continuous"
 e["Problem"]["Environment Function"] = env
-e["Problem"]["Training Reward Threshold"] = 750
-e["Problem"]["Policy Testing Episodes"] = 1
 e["Problem"]["Actions Between Policy Updates"] = 500
+e["Problem"]["Training Reward Threshold"] = 450
+e["Problem"]["Policy Testing Episodes"] = 10
+
+### Defining State variables
 
 e["Variables"][0]["Name"] = "Cart Position"
-e["Variables"][1]["Name"] = "Angle 1"
-e["Variables"][2]["Name"] = "Car Velocity"
-e["Variables"][3]["Name"] = "Angular Velocity 1"
-e["Variables"][4]["Name"] = "Height Proxy"
+e["Variables"][1]["Name"] = "Cart Velocity"
+e["Variables"][2]["Name"] = "Pole Angle"
+e["Variables"][3]["Name"] = "Pole Angular Velocity"
 
-e["Variables"][5]["Name"] = "Force"
-e["Variables"][5]["Type"] = "Action"
-e["Variables"][5]["Lower Bound"] = -20.0
-e["Variables"][5]["Upper Bound"] = +20.0
-e["Variables"][5]["Initial Exploration Noise"] = 2.00
+### Defining Action variables 
+
+e["Variables"][4]["Name"] = "Force"
+e["Variables"][4]["Type"] = "Action"
+e["Variables"][4]["Lower Bound"] = -10.0
+e["Variables"][4]["Upper Bound"] = +10.0
+e["Variables"][4]["Initial Exploration Noise"] = 1.0
 
 ### Defining Agent Configuration 
 
-e["Solver"]["Type"] = "Agent / Continuous / GFPT"
+e["Solver"]["Type"] = "Agent / Continuous / DDPG"
 e["Solver"]["Mode"] = "Training"
-e["Solver"]["Episodes Per Generation"] = 1
+e["Solver"]["Episodes Per Generation"] = 10
 e["Solver"]["Experiences Between Policy Updates"] = 10
+e["Solver"]["Discount Factor"] = 0.99
+
+e["Solver"]["Learning Rate"] = 0.001
+e["Solver"]["Policy"]["Learning Rate Scale"] = 0.1
+e["Solver"]["Policy"]["Adoption Rate"] = 0.1
 
 ### Defining the configuration of replay memory
 
-e["Solver"]["Experience Replay"]["Start Size"] = 4096
-e["Solver"]["Experience Replay"]["Maximum Size"] = 65536
+e["Solver"]["Mini Batch Size"] = 32
+e["Solver"]["Mini Batch Strategy"] = "Uniform"
+e["Solver"]["Experience Replay"]["Start Size"] =   1024
+e["Solver"]["Experience Replay"]["Maximum Size"] = 32768
 
 ### Configuring the Remember-and-Forget Experience Replay algorithm
 
@@ -49,20 +59,7 @@ e["Solver"]["Experience Replay"]["Off Policy"]["Target"] = 0.1
 e["Solver"]["Experience Replay"]["Off Policy"]["Annealing Rate"] = 5e-7
 e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
 
-### Configuring Mini Batch
-
-e["Solver"]["Mini Batch Size"] = 128
-e["Solver"]["Mini Batch Strategy"] = "Uniform"
- 
-### Defining Critic and Policy Configuration
-
-e["Solver"]["Learning Rate"] = 0.001
-e["Solver"]["Policy"]["Target Accuracy"] = 0.000001
-e["Solver"]["Policy"]["Optimization Candidates"] = 64
-
 ### Configuring the neural network and its hidden layers
-
-e["Solver"]["Time Sequence Length"] = 1
 
 e["Solver"]["Neural Network"]["Engine"] = "OneDNN"
 
@@ -80,13 +77,15 @@ e["Solver"]["Neural Network"]["Hidden Layers"][3]["Function"] = "Elementwise/Tan
 
 ### Defining Termination Criteria
 
-e["Solver"]["Termination Criteria"]["Testing"]["Target Average Reward"] = 900
+e["Solver"]["Termination Criteria"]["Testing"]["Target Average Reward"] = 450
 
 ### Setting file output configuration
 
 e["Console Output"]["Verbosity"] = "Detailed"
-e["File Output"]["Enabled"] = False
+e["File Output"]["Enabled"] = True
+e["File Output"]["Frequency"] = 1
  
 ### Running Training Experiment
 
 k.run(e)
+

--- a/examples/learning/reinforcement/cartpole/run-dqn.py
+++ b/examples/learning/reinforcement/cartpole/run-dqn.py
@@ -39,7 +39,6 @@ e["Variables"][4]["Type"] = "Action"
 e["Solver"]["Type"] = "Agent / Discrete / DQN"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Experiences Between Policy Updates"] = 1
-e["Solver"]["Cache Persistence"] = 1
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Target Update Frequency"] = 100
 
@@ -54,7 +53,6 @@ e["Solver"]["Random Action Probability"] = 0.05
 
 ## Defining Q-Critic and Action-selection (policy) optimizers
 
-#e["Solver"]["Optimizer"] = "GradientDescendent"
 e["Solver"]["Optimizer"] = "AdaBelief"
 e["Solver"]["Discount Factor"] = 0.99
 e["Solver"]["Learning Rate"] = 1e-4

--- a/examples/learning/reinforcement/cartpole/run-gfpt.py
+++ b/examples/learning/reinforcement/cartpole/run-gfpt.py
@@ -50,10 +50,16 @@ e["Solver"]["Experience Replay"]["Maximum Size"] = 32768
 
 ## Defining Critic and Policy Configuration
 
-e["Solver"]["Learning Rate"] = 0.01
-e["Solver"]["Policy"]["Learning Rate Scale"] = 1.0
-e["Solver"]["Policy"]["Target Accuracy"] = 0.01
-e["Solver"]["Policy"]["Optimization Candidates"] = 32
+e["Solver"]["Learning Rate"] = 0.0001
+e["Solver"]["Policy"]["Target Accuracy"] = 0.000001
+e["Solver"]["Policy"]["Optimization Candidates"] = 64
+
+### Configuring the Remember-and-Forget Experience Replay algorithm
+
+e["Solver"]["Experience Replay"]["Off Policy"]["Cutoff Scale"] = 4.0
+e["Solver"]["Experience Replay"]["Off Policy"]["Target"] = 0.1
+e["Solver"]["Experience Replay"]["Off Policy"]["Annealing Rate"] = 5e-7
+e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
 
 ### Configuring the neural network and its hidden layers
 

--- a/examples/learning/reinforcement/cartpole/run-gfpt.py
+++ b/examples/learning/reinforcement/cartpole/run-gfpt.py
@@ -39,7 +39,6 @@ e["Solver"]["Type"] = "Agent / Continuous / GFPT"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 10
 e["Solver"]["Experiences Between Policy Updates"] = 10
-e["Solver"]["Cache Persistence"] = 50
 e["Solver"]["Discount Factor"] = 0.99
 
 ### Defining the configuration of replay memory

--- a/examples/learning/reinforcement/cartpole/run-vracer-continuous.py
+++ b/examples/learning/reinforcement/cartpole/run-vracer-continuous.py
@@ -42,7 +42,6 @@ e["Solver"]["Type"] = "Agent / Continuous / VRACER"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Experiences Between Policy Updates"] = 10
 e["Solver"]["Episodes Per Generation"] = 1
-e["Solver"]["Cache Persistence"] = 100
 
 ### Defining the configuration of replay memory
 

--- a/examples/learning/reinforcement/cartpole/run-vracer-discrete.py
+++ b/examples/learning/reinforcement/cartpole/run-vracer-discrete.py
@@ -39,7 +39,6 @@ e["Variables"][4]["Type"] = "Action"
 e["Solver"]["Type"] = "Agent / Discrete / DVRACER"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Experiences Between Policy Updates"] = 10
-e["Solver"]["Cache Persistence"] = 500
 e["Solver"]["Episodes Per Generation"] = 1
 
 ### Defining Experience Replay configuration

--- a/examples/learning/reinforcement/lander/run-gfpt.py
+++ b/examples/learning/reinforcement/lander/run-gfpt.py
@@ -44,7 +44,6 @@ e["Solver"]["Mode"] = "Training"
 e["Solver"]["Learning Rate"] = 0.01
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 10
-e["Solver"]["Cache Persistence"] = 100
 e["Solver"]["Discount Factor"] = 0.99
 
 ### Defining the configuration of replay memory

--- a/examples/learning/reinforcement/lander/run-gfpt.py
+++ b/examples/learning/reinforcement/lander/run-gfpt.py
@@ -41,7 +41,6 @@ e["Variables"][3]["Initial Exploration Noise"] = 0.02
 
 e["Solver"]["Type"] = "Agent / Continuous / GFPT"
 e["Solver"]["Mode"] = "Training"
-e["Solver"]["Learning Rate"] = 0.01
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 10
 e["Solver"]["Discount Factor"] = 0.99
@@ -56,11 +55,18 @@ e["Solver"]["Mini Batch Strategy"] = "Uniform"
 e["Solver"]["Experience Replay"]["Start Size"] = 4096
 e["Solver"]["Experience Replay"]["Maximum Size"] = 65536
 
-### Defining Critic and Policy Configuration
+### Configuring the Remember-and-Forget Experience Replay algorithm
 
-e["Solver"]["Policy"]["Learning Rate Scale"] = 0.1
-e["Solver"]["Policy"]["Target Accuracy"] = 0.001
-e["Solver"]["Policy"]["Optimization Candidates"] = 32
+e["Solver"]["Experience Replay"]["Off Policy"]["Cutoff Scale"] = 4.0
+e["Solver"]["Experience Replay"]["Off Policy"]["Target"] = 0.1
+e["Solver"]["Experience Replay"]["Off Policy"]["Annealing Rate"] = 5e-7
+e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
+
+## Defining Critic and Policy Configuration
+
+e["Solver"]["Learning Rate"] = 0.001
+e["Solver"]["Policy"]["Target Accuracy"] = 0.000001
+e["Solver"]["Policy"]["Optimization Candidates"] = 64
 
 ### Configuring the neural network and its hidden layers
 

--- a/examples/learning/reinforcement/upswing/run-ddpg-double.py
+++ b/examples/learning/reinforcement/upswing/run-ddpg-double.py
@@ -2,7 +2,7 @@
 import os
 import sys
 sys.path.append('./_model')
-from single_env import *
+from double_env import *
 
 ####### Defining Korali Problem
 
@@ -15,27 +15,32 @@ e = korali.Experiment()
 e["Problem"]["Type"] = "Reinforcement Learning / Continuous"
 e["Problem"]["Environment Function"] = env
 e["Problem"]["Training Reward Threshold"] = 750
-e["Problem"]["Policy Testing Episodes"] = 1
-e["Problem"]["Actions Between Policy Updates"] = 500
+e["Problem"]["Policy Testing Episodes"] = 10
+e["Problem"]["Actions Between Policy Updates"] = 1
 
 e["Variables"][0]["Name"] = "Cart Position"
-e["Variables"][1]["Name"] = "Angle 1"
-e["Variables"][2]["Name"] = "Car Velocity"
+e["Variables"][1]["Name"] = "Cart Velocity"
+e["Variables"][2]["Name"] = "Angle 1"
 e["Variables"][3]["Name"] = "Angular Velocity 1"
-e["Variables"][4]["Name"] = "Height Proxy"
+e["Variables"][4]["Name"] = "Angle 2"
+e["Variables"][5]["Name"] = "Angular Velocity 2"
+e["Variables"][6]["Name"] = "Height Proxy"
 
-e["Variables"][5]["Name"] = "Force"
-e["Variables"][5]["Type"] = "Action"
-e["Variables"][5]["Lower Bound"] = -20.0
-e["Variables"][5]["Upper Bound"] = +20.0
-e["Variables"][5]["Initial Exploration Noise"] = 2.00
+e["Variables"][7]["Name"] = "Force"
+e["Variables"][7]["Type"] = "Action"
+e["Variables"][7]["Lower Bound"] = -20.0
+e["Variables"][7]["Upper Bound"] = +20.0
+e["Variables"][7]["Initial Exploration Noise"] = 2.00
 
 ### Defining Agent Configuration 
 
-e["Solver"]["Type"] = "Agent / Continuous / GFPT"
+e["Solver"]["Type"] = "Agent / Continuous / DDPG"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 10
+e["Solver"]["Learning Rate"] = 0.001
+e["Solver"]["Policy"]["Learning Rate Scale"] = 0.1
+e["Solver"]["Policy"]["Adoption Rate"] = 0.1
 
 ### Defining the configuration of replay memory
 
@@ -53,12 +58,6 @@ e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
 
 e["Solver"]["Mini Batch Size"] = 128
 e["Solver"]["Mini Batch Strategy"] = "Uniform"
- 
-### Defining Critic and Policy Configuration
-
-e["Solver"]["Learning Rate"] = 0.001
-e["Solver"]["Policy"]["Target Accuracy"] = 0.000001
-e["Solver"]["Policy"]["Optimization Candidates"] = 64
 
 ### Configuring the neural network and its hidden layers
 

--- a/examples/learning/reinforcement/upswing/run-ddpg-single.py
+++ b/examples/learning/reinforcement/upswing/run-ddpg-single.py
@@ -32,10 +32,13 @@ e["Variables"][5]["Initial Exploration Noise"] = 2.00
 
 ### Defining Agent Configuration 
 
-e["Solver"]["Type"] = "Agent / Continuous / GFPT"
+e["Solver"]["Type"] = "Agent / Continuous / DDPG"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 10
+e["Solver"]["Learning Rate"] = 0.001
+e["Solver"]["Policy"]["Learning Rate Scale"] = 0.1
+e["Solver"]["Policy"]["Adoption Rate"] = 0.1
 
 ### Defining the configuration of replay memory
 
@@ -53,12 +56,6 @@ e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
 
 e["Solver"]["Mini Batch Size"] = 128
 e["Solver"]["Mini Batch Strategy"] = "Uniform"
- 
-### Defining Critic and Policy Configuration
-
-e["Solver"]["Learning Rate"] = 0.001
-e["Solver"]["Policy"]["Target Accuracy"] = 0.000001
-e["Solver"]["Policy"]["Optimization Candidates"] = 64
 
 ### Configuring the neural network and its hidden layers
 

--- a/examples/learning/reinforcement/upswing/run-gfpt-double.py
+++ b/examples/learning/reinforcement/upswing/run-gfpt-double.py
@@ -38,23 +38,29 @@ e["Solver"]["Type"] = "Agent / Continuous / GFPT"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 10
-e["Solver"]["Learning Rate"] = 0.001
 
 ### Defining the configuration of replay memory
 
 e["Solver"]["Experience Replay"]["Start Size"] = 4096
 e["Solver"]["Experience Replay"]["Maximum Size"] = 65536
 
+### Configuring the Remember-and-Forget Experience Replay algorithm
+
+e["Solver"]["Experience Replay"]["Off Policy"]["Cutoff Scale"] = 4.0
+e["Solver"]["Experience Replay"]["Off Policy"]["Target"] = 0.1
+e["Solver"]["Experience Replay"]["Off Policy"]["Annealing Rate"] = 5e-7
+e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
+
 ### Configuring Mini Batch
 
 e["Solver"]["Mini Batch Size"] = 128
 e["Solver"]["Mini Batch Strategy"] = "Uniform"
 
-## Defining Critic and Policy Configuration
+### Defining Critic and Policy Configuration
 
-e["Solver"]["Policy"]["Learning Rate Scale"] = 1.0
-e["Solver"]["Policy"]["Target Accuracy"] = 0.05
-e["Solver"]["Policy"]["Optimization Candidates"] = 32
+e["Solver"]["Learning Rate"] = 0.001
+e["Solver"]["Policy"]["Target Accuracy"] = 0.000001
+e["Solver"]["Policy"]["Optimization Candidates"] = 64
 
 ### Configuring the neural network and its hidden layers
 

--- a/examples/learning/reinforcement/upswing/run-gfpt-double.py
+++ b/examples/learning/reinforcement/upswing/run-gfpt-double.py
@@ -38,7 +38,6 @@ e["Solver"]["Type"] = "Agent / Continuous / GFPT"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 10
-e["Solver"]["Cache Persistence"] = 200
 e["Solver"]["Learning Rate"] = 0.001
 
 ### Defining the configuration of replay memory

--- a/examples/learning/reinforcement/upswing/run-gfpt-single.py
+++ b/examples/learning/reinforcement/upswing/run-gfpt-single.py
@@ -36,7 +36,6 @@ e["Solver"]["Type"] = "Agent / Continuous / GFPT"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 10
-e["Solver"]["Cache Persistence"] = 100
 e["Solver"]["Learning Rate"] = 0.001
 
 ### Defining the configuration of replay memory

--- a/examples/learning/reinforcement/upswing/run-vracer-double.py
+++ b/examples/learning/reinforcement/upswing/run-vracer-double.py
@@ -42,7 +42,6 @@ e["Solver"]["Type"] = "Agent / Continuous / VRACER"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 1
-e["Solver"]["Cache Persistence"] = 500
 e["Solver"]["Policy Distribution"] = "Normal"
 e["Solver"]["Discount Factor"] = 0.99
 e["Solver"]["Learning Rate"] = 1e-4

--- a/examples/learning/reinforcement/upswing/run-vracer-single.py
+++ b/examples/learning/reinforcement/upswing/run-vracer-single.py
@@ -40,7 +40,6 @@ e["Solver"]["Type"] = "Agent / Continuous / VRACER"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
 e["Solver"]["Experiences Between Policy Updates"] = 1
-e["Solver"]["Cache Persistence"] = 500
 e["Solver"]["Policy Distribution"] = "Normal"
 e["Solver"]["Discount Factor"] = 0.99
 e["Solver"]["Learning Rate"] = 1e-4

--- a/examples/study.cases/ABF3D/Makefile
+++ b/examples/study.cases/ABF3D/Makefile
@@ -1,4 +1,4 @@
-BINARIES = run-gfpt run-vracer
+BINARIES = run-gfpt run-vracer run-ddpg
 KORALICXX=$(shell python3 -m korali.cxx --compiler)
 KORALICFLAGS=`python3 -m korali.cxx --cflags`
 KORALILIBS=`python3 -m korali.cxx --libs`

--- a/examples/study.cases/ABF3D/run-gfpt.cpp
+++ b/examples/study.cases/ABF3D/run-gfpt.cpp
@@ -8,17 +8,18 @@ int main(int argc, char *argv[])
   _resultDir = "_result_gfpt";
   initializeEnvironment("_config/helix_2d_eu_const.json");
 
+  auto e = korali::Experiment();
+
   ////// Checking if existing results are there and continuing them
 
-  auto e = korali::Experiment();
-  auto found = e.loadState(_resultDir + std::string("/latest"));
-  if (found == true) printf("Continuing execution from previous run...\n");
+  //auto found = e.loadState(_resultDir + std::string("/latest"));
+  //if (found == true) printf("Continuing execution from previous run...\n");
 
   ////// Defining problem configuration
 
   e["Problem"]["Type"] = "Reinforcement Learning / Continuous";
   e["Problem"]["Environment Function"] = &runEnvironment;
-  e["Problem"]["Training Reward Threshold"] = 1.0;
+  e["Problem"]["Training Reward Threshold"] = 1.5;
   e["Problem"]["Policy Testing Episodes"] = 20;
   e["Problem"]["Actions Between Policy Updates"] = 1;
 
@@ -71,9 +72,10 @@ int main(int argc, char *argv[])
   e["Solver"]["Mode"] = "Training";
   e["Solver"]["Episodes Per Generation"] = 1;
   e["Solver"]["Experiences Between Policy Updates"] = 1;
-  e["Solver"]["Cache Persistence"] = 243;
-  e["Solver"]["Learning Rate"] = 0.0001;
-  e["Solver"]["Discount Factor"] = 0.995;
+  e["Solver"]["Learning Rate"] = 1e-4;
+  e["Solver"]["Policy"]["Optimization Candidates"] = 16;
+  e["Solver"]["Policy"]["Target Accuracy"] = 0.00001f;
+  e["Solver"]["Discount Factor"] = 0.99;
 
   /// Defining the configuration of replay memory
 
@@ -82,22 +84,15 @@ int main(int argc, char *argv[])
 
   /// Configuring the Remember-and-Forget Experience Replay algorithm
 
-  e["Solver"]["Experience Replay"]["REFER"]["Enabled"] = true;
-  e["Solver"]["Experience Replay"]["REFER"]["Cutoff Scale"] = 4.0;
-  e["Solver"]["Experience Replay"]["REFER"]["Target"] = 0.1;
-  e["Solver"]["Experience Replay"]["REFER"]["Initial Beta"] = 0.6;
-  e["Solver"]["Experience Replay"]["REFER"]["Annealing Rate"] = 5e-7;
+  e["Solver"]["Experience Replay"]["Off Policy"]["Cutoff Scale"] = 4.0;
+  e["Solver"]["Experience Replay"]["Off Policy"]["Target"] = 0.1;
+  e["Solver"]["Experience Replay"]["Off Policy"]["Annealing Rate"] = 5e-7;
+  e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3;
 
   /// Configuring Mini Batch
 
   e["Solver"]["Mini Batch Size"] = 256;
   e["Solver"]["Mini Batch Strategy"] = "Uniform";
-
-  /// Defining Critic and Policy Configuration
-
-  e["Solver"]["Policy"]["Learning Rate Scale"] = 1.0;
-  e["Solver"]["Policy"]["Target Accuracy"] = 0.005;
-  e["Solver"]["Policy"]["Optimization Candidates"] = 128;
 
   /// Configuring the neural network and its hidden layers
 
@@ -117,14 +112,13 @@ int main(int argc, char *argv[])
 
   ////// Defining Termination Criteria
 
-  e["Solver"]["Termination Criteria"]["Testing"]["Target Average Reward"] = 1.3;
+  e["Solver"]["Termination Criteria"]["Testing"]["Target Average Reward"] = 1.5;
 
   ////// Setting file output configuration
 
-  e["Solver"]["Experience Replay"]["Serialize"] = false;
   e["Console Output"]["Verbosity"] = "Detailed";
   e["File Output"]["Enabled"] = true;
-  e["File Output"]["Frequency"] = 4;
+  e["File Output"]["Frequency"] = 10;
   e["File Output"]["Path"] = _resultDir;
 
   auto k = korali::Engine();

--- a/examples/study.cases/ABF3D/run-vracer.cpp
+++ b/examples/study.cases/ABF3D/run-vracer.cpp
@@ -72,7 +72,6 @@ int main(int argc, char *argv[])
   e["Solver"]["Mode"] = "Training";
   e["Solver"]["Episodes Per Generation"] = 1;
   e["Solver"]["Experiences Between Policy Updates"] = 1;
-  e["Solver"]["Cache Persistence"] = 200;
   e["Solver"]["Learning Rate"] = 1e-4;
   e["Solver"]["Discount Factor"] = 0.99;
 

--- a/examples/study.cases/openAIGym/.gitignore
+++ b/examples/study.cases/openAIGym/.gitignore
@@ -2,3 +2,4 @@ movie
 MUJOCO_LOG.TXT
 _movie
 _results
+_model/pyBulletEnvironments/

--- a/examples/study.cases/openAIGym/.run_test.sh
+++ b/examples/study.cases/openAIGym/.run_test.sh
@@ -24,9 +24,7 @@ rm -rf __test-*; check_result
 
 for file in *.py
 do
- sed -e 's%Defining Termination Criteria%Defining Termination Criteria\ne["Solver"]["Termination Criteria"]["Max Generations"] = 30\n%g' \
-     -e 's%k.run(e)%k.run(e); exit(0);\n%g' \
-        ${file} > __test-${file}; check_result
+ sed -e 's%\["Max Generations"\] =%["Max Generations"] = 20 #%g' ${file} > __test-${file}; check_result
 done
 
 ##### Running Test
@@ -34,7 +32,7 @@ done
 for file in __test-*.py
 do
  echo "Running ${file} ..."
- OMP_NUM_THREADS=4 python3 ${file}; check_result
+ OMP_NUM_THREADS=4 python3 ${file} --env Ant-v2; check_result
 done
 
 ##### Deleting Tests

--- a/examples/study.cases/openAIGym/_jobs/openAIGym_GFPT.sbatch
+++ b/examples/study.cases/openAIGym/_jobs/openAIGym_GFPT.sbatch
@@ -1,0 +1,52 @@
+#!/bin/bash -l
+#SBATCH --job-name="OpenAIGym_GFPT"
+#SBATCH --output=OpenAIGym_GFPT_%j.out
+#SBATCH --time=24:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --account=eth2
+#SBATCH --cpus-per-task=1
+#SBATCH --partition=normal
+#SBATCH --constraint=mc
+
+# Choose Environment
+#env=Ant-v2
+#env=HalfCheetah-v2
+#env=Hopper-v2
+#env=Humanoid-v2
+#env=HumanoidStandup-v2
+#env=InvertedDoublePendulum-v2
+#env=InvertedPendulum-v2
+#env=Reacher-v2
+#env=Swimmer-v2
+#env=Walker2d-v2
+
+env=AntBulletEnv-v0
+#env=HalfCheetahBulletEnv-v0
+#env=HopperBulletEnv-v0
+#env=HumanoidBulletEnv-v0
+#env=HumanoidFlagrunHarderBulletEnv-v0
+#env=InvertedDoublePendulumBulletEnv-v0
+#env=InvertedPendulumBulletEnv-v0
+#env=InvertedPendulumSwingupBulletEnv-v0
+#env=Walker2DBulletEnv-v0
+
+pushd ..
+
+cat run-gfpt.py
+
+expDir=$SCRATCH/OpenAIGym_GFPT/$SLURM_JOB_ID
+mkdir -p $expDir
+cp run-gfpt.py $expDir
+cp -r _model $expDir
+
+popd
+
+pushd $expDir
+
+OMP_NUM_THREADS=36 python3 run-gfpt.py --env $env
+
+popd
+
+date

--- a/examples/study.cases/openAIGym/_jobs/openAIGym_VRACER.sbatch
+++ b/examples/study.cases/openAIGym/_jobs/openAIGym_VRACER.sbatch
@@ -1,0 +1,52 @@
+#!/bin/bash -l
+#SBATCH --job-name="OpenAIGym_VRACER"
+#SBATCH --output=OpenAIGym_VRACER_%j.out
+#SBATCH --time=24:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --account=eth2
+#SBATCH --cpus-per-task=1
+#SBATCH --partition=normal
+#SBATCH --constraint=mc
+
+# Choose Environment
+#env=Ant-v2
+#env=HalfCheetah-v2
+#env=Hopper-v2
+#env=Humanoid-v2
+#env=HumanoidStandup-v2
+#env=InvertedDoublePendulum-v2
+#env=InvertedPendulum-v2
+#env=Reacher-v2
+#env=Swimmer-v2
+#env=Walker2d-v2
+
+env=AntBulletEnv-v0
+#env=HalfCheetahBulletEnv-v0
+#env=HopperBulletEnv-v0
+#env=HumanoidBulletEnv-v0
+#env=HumanoidFlagrunHarderBulletEnv-v0
+#env=InvertedDoublePendulumBulletEnv-v0
+#env=InvertedPendulumBulletEnv-v0
+#env=InvertedPendulumSwingupBulletEnv-v0
+#env=Walker2DBulletEnv-v0
+
+pushd ..
+
+cat run-vracer.py
+
+expDir=$SCRATCH/OpenAIGym_VRACER/$SLURM_JOB_ID
+mkdir -p $expDir
+cp run-vracer.py $expDir
+cp -r _model $expDir
+
+popd
+
+pushd $expDir
+
+OMP_NUM_THREADS=36 python3 run-vracer.py --env $env
+
+popd
+
+date

--- a/examples/study.cases/openAIGym/install_deps.sh
+++ b/examples/study.cases/openAIGym/install_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir _model/pyBulletEnvironments
-git clone git@github.com:bulletphysics/bullet3.git
+git clone https://github.com/bulletphysics/bullet3.git
 cp bullet3/examples/pybullet/gym/pybullet_envs/* _model/pyBulletEnvironments
 rm -rf ./bullet3/ _model/pyBulletEnvironments/kerasrl_utils.py
 pip install pybullet --user

--- a/examples/study.cases/openAIGym/run-ddpg.py
+++ b/examples/study.cases/openAIGym/run-ddpg.py
@@ -19,7 +19,7 @@ e = korali.Experiment()
 
 ### Defining results folder and loading previous results, if any
 
-resultFolder = '_result_vracer/' 
+resultFolder = '_result_ddpg/' 
 e.loadState(resultFolder + '/latest');
 
 ### Initializing openAI Gym environment
@@ -28,14 +28,14 @@ initEnvironment(e, args.env)
 
 ### Defining Agent Configuration 
 
-e["Solver"]["Type"] = "Agent / Continuous / VRACER"
+e["Solver"]["Type"] = "Agent / Continuous / DDPG"
 e["Solver"]["Mode"] = "Training"
-e["Solver"]["Experiences Between Policy Updates"] = 1
 e["Solver"]["Episodes Per Generation"] = 1
-e["Solver"]["Policy Distribution"] = "Normal"
-e["Solver"]["Discount Factor"] = 0.995
+e["Solver"]["Experiences Between Policy Updates"] = 1
 e["Solver"]["Learning Rate"] = 1e-4
-e["Solver"]["Mini Batch Size"] = 256
+e["Solver"]["Discount Factor"] = 0.995
+e["Solver"]["Policy"]["Learning Rate Scale"] = 0.1
+e["Solver"]["Policy"]["Adoption Rate"] = 0.01
 
 ### Defining the configuration of replay memory
 
@@ -48,6 +48,11 @@ e["Solver"]["Experience Replay"]["Off Policy"]["Cutoff Scale"] = 4.0
 e["Solver"]["Experience Replay"]["Off Policy"]["Target"] = 0.1
 e["Solver"]["Experience Replay"]["Off Policy"]["Annealing Rate"] = 5e-7
 e["Solver"]["Experience Replay"]["Off Policy"]["REFER Beta"] = 0.3
+
+### Configuring Mini Batch
+
+e["Solver"]["Mini Batch Size"] = 128
+e["Solver"]["Mini Batch Strategy"] = "Uniform"
 
 ### Configuring the neural network and its hidden layers
 
@@ -65,7 +70,7 @@ e["Solver"]["Neural Network"]["Hidden Layers"][2]["Output Channels"] = 128
 e["Solver"]["Neural Network"]["Hidden Layers"][3]["Type"] = "Layer/Activation"
 e["Solver"]["Neural Network"]["Hidden Layers"][3]["Function"] = "Elementwise/Tanh"
 
-### Setting file output configuration
+### Setting console/file output configuration
 
 e["Solver"]["Termination Criteria"]["Max Generations"] = 100000
 e["Solver"]["Experience Replay"]["Serialize"] = True
@@ -77,3 +82,4 @@ e["File Output"]["Path"] = resultFolder
 ### Running Experiment
 
 k.run(e)
+

--- a/source/modules/module.cpp
+++ b/source/modules/module.cpp
@@ -43,6 +43,7 @@
 #include "problem/sampling/sampling.hpp"
 #include "problem/supervisedLearning/supervisedLearning.hpp"
 #include "solver/SAEM/SAEM.hpp"
+#include "solver/agent/continuous/DDPG/DDPG.hpp"
 #include "solver/agent/continuous/GFPT/GFPT.hpp"
 #include "solver/agent/continuous/NAF/NAF.hpp"
 #include "solver/agent/continuous/VRACER/VRACER.hpp"
@@ -140,6 +141,7 @@ Module *Module::getModule(knlohmann::json &js, Experiment *e)
   if (iCompare(moduleType, "Agent/Discrete/DQN")) module = new korali::solver::agent::discrete::DQN();
   if (iCompare(moduleType, "Agent/Discrete/DVRACER")) module = new korali::solver::agent::discrete::dVRACER();
   if (iCompare(moduleType, "Agent/Continuous/GFPT")) module = new korali::solver::agent::continuous::GFPT();
+  if (iCompare(moduleType, "Agent/Continuous/DDPG")) module = new korali::solver::agent::continuous::DDPG();
   if (iCompare(moduleType, "Agent/Continuous/NAF")) module = new korali::solver::agent::continuous::NAF();
   if (iCompare(moduleType, "Agent/Continuous/VRACER")) module = new korali::solver::agent::continuous::VRACER();
   if (iCompare(moduleType, "Optimizer/CMAES")) module = new korali::solver::optimizer::CMAES();

--- a/source/modules/neuralNetwork/layer/layer._cpp
+++ b/source/modules/neuralNetwork/layer/layer._cpp
@@ -68,6 +68,45 @@ void Layer::createForwardPipeline()
 #endif
 }
 
+std::vector<std::vector<float>> Layer::getOutput()
+{
+  size_t N = _nn->_batchSize;
+  size_t OC = _outputChannels;
+  int t = _nn->_timestepCount - 1;
+
+  std::vector<float> outputVals(N * OC);
+
+// Copying previous layer's output to this layer's output
+#ifdef _KORALI_USE_EIGEN
+  if (_nn->_engine == "Korali")
+  {
+    memcpy(outputVals.data(), _outputValues, N * OC * sizeof(float));
+  }
+#endif
+
+#ifdef _KORALI_USE_ONEDNN
+  if (_nn->_engine == "OneDNN")
+  {
+    read_from_dnnl_memory(outputVals.data(), _outputMem[t]);
+  }
+#endif
+
+#ifdef _KORALI_USE_CUDNN
+  if (_nn->_engine == "CuDNN")
+  {
+    cudaErrCheck(cudaMemcpy(outputVals.data(), _outputTensor[t], N * OC * sizeof(float), cudaMemcpyDeviceToHost));
+  }
+#endif
+
+  std::vector<std::vector<float>> outputVector(N);
+  for (size_t i = 0; i < N; i++) outputVector[i].resize(OC);
+  for (size_t i = 0; i < N; i++)
+    for (size_t j = 0; j < OC; j++)
+      outputVector[i][j] = outputVals[i * OC + j];
+
+  return outputVector;
+}
+
 void Layer::createBackwardPipeline()
 {
   if (_nn->_mode == "Inference")

--- a/source/modules/neuralNetwork/layer/layer._hpp
+++ b/source/modules/neuralNetwork/layer/layer._hpp
@@ -106,6 +106,12 @@ class Layer : public Module
 #endif
 
   /**
+   * @brief Returns the output values for the current layer
+   * @return The output values
+   */
+  std::vector<std::vector<float>> getOutput();
+
+  /**
    * @brief Generates the initial weight/bias hyperparameters for the layer
    * @return The initial hyperparameters
    */

--- a/source/modules/problem/reinforcementLearning/reinforcementLearning._cpp
+++ b/source/modules/problem/reinforcementLearning/reinforcementLearning._cpp
@@ -132,6 +132,9 @@ void ReinforcementLearning::runTrainingEpisode(Sample &agent)
     // Storing termination status
     experience["Termination"] = agent["Termination"];
 
+    // Adding metadata from the agent module
+    experience["Metadata"] = agent["Metadata"];
+
     // If the episode was truncated, then save the terminal state
     if (agent["Termination"] == "Truncated") experience["Truncated State"] = agent["State"];
 

--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -423,6 +423,7 @@ void Agent::processEpisode(std::vector<knlohmann::json> &episode)
     retV = _discountFactor * retV + _experienceReplay[expId].reward;
 
     // Setting initial retrace value in the experience's cache
+    _experienceReplay[expId].policy["State Value"] = retV;
     _experienceReplay[expId].cache.set("Retrace Value", retV);
   }
 
@@ -606,10 +607,10 @@ float Agent::retraceFunction(size_t expId)
     auto expAction = _experienceReplay[curId].action;
 
     // Calculating state value function
-    float curV = stateValueFunction(expStateSequence);
+    float curV = _experienceReplay[curId].policy["State Value"];
 
     // Calculating importance weight
-    float importanceWeight = getExperienceImportanceWeight(curId);
+    float importanceWeight = _experienceReplay[curId].policy["Importance Weight"];
 
     // Truncate importance weight
     float truncatedImportanceWeight = std::min(1.0f, importanceWeight);

--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -542,10 +542,47 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
       miniBatch[batchIdx++] = std::floor(_uniformGenerator->getRandomNumber() * (float)(_experienceReplay.size() - 1));
   }
 
-  // Update metadata for the minibatch experiences
+  /**********************************************
+   * Updating experience's metadata
+   *********************************************/
+
   #pragma omp parallel for schedule(dynamic, 1)
   for (size_t i = 0; i < size; i++)
-   updateExperienceMetadata(miniBatch[i]);
+  {
+   auto expId = miniBatch[i];
+
+   // Get state, action, mean, Sigma for this experience
+   auto expStateSequence = getStateTimeSequence(expId);
+   auto expAction = _experienceReplay[expId].action;
+   auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
+
+   // Running policy for the current state
+   auto curPolicy = runPolicy(expStateSequence);
+
+   // Get state value function
+   auto V = stateValueFunction(expStateSequence);
+
+   // Compute importance weight
+   float importanceWeight = calculateImportanceWeight(expAction, curPolicy, expPolicy);
+
+   // If this is the truncated experience of an episode, then obtain truncated state value
+   float truncatedV = 0.0f;
+   if (_experienceReplay[expId].termination == e_truncated)
+    truncatedV = stateValueFunction(getTruncatedStateTimeSequence(expId));
+
+   // Store computed information for use in retrace.
+   #pragma omp critical
+   {
+    _experienceReplay[expId].metadata["State Value"] = V;
+    if (_experienceReplay[expId].termination == e_truncated)  _experienceReplay[expId].metadata["Truncated State Value"] = truncatedV;
+    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
+    _experienceReplay[expId].metadata["Current Policy"] = curPolicy;
+   }
+  }
+
+  /**************************************************
+   * Calculating retrace value for selected experience
+   *************************************************/
 
   // Selecting experiences, such that only one (the most advanced) per unique episode remains
   std::map<size_t, size_t> episodeMaxExperienceAge;
@@ -603,14 +640,14 @@ float Agent::retraceFunction(size_t expId)
   // Finding last experience in the episode that corresponds to expId
   ssize_t endId = expId;
   ssize_t startId = endId;
-  while (_experienceReplay[startId].metadata["Experience Position"] > 0 && startId > 0) startId--;
+  while (_experienceReplay[startId].metadata["Episode Position"] > 0 && startId > 0) startId--;
 
   // Storage for the retrace value
   float retV = 0.0f;
 
   // If it was a truncated episode, add the value function for the terminal state to retV
   if (_experienceReplay[expId].termination == e_truncated)
-    retV = stateValueFunction(getTruncatedStateTimeSequence(endId));
+    retV = _experienceReplay[expId].metadata["Truncated State Value"];
 
   if (_experienceReplay[expId].termination == e_nonTerminal)
     retV = _experienceReplay[expId + 1].metadata["Retrace Value"];
@@ -746,7 +783,7 @@ void Agent::serializeExperienceReplay()
     stateJson["Experience Replay"][i]["Metadata"] = _experienceReplay[i].metadata;
   }
 
-  // Storing training/testing policies
+//  // Storing training/testing policies
   stateJson["Training"]["Current Policy"] = _trainingCurrentPolicy;
   stateJson["Training"]["Best Policy"] = _trainingBestPolicy;
   stateJson["Testing"]["Best Policy"] = _testingBestPolicy;

--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -273,8 +273,11 @@ void Agent::attendAgent(size_t agentId)
 
     if (isTerminal)
     {
+      // Getting episode Id
+      size_t episodeId = _agents[agentId]["Sample Id"];
+
       //  Now that we have the entire episode, process its experiences (add them to replay memory)
-      processEpisode(_episodes[agentId]);
+      processEpisode(episodeId, _episodes[agentId]);
 
       // Increasing total experience counters
       _experienceCount += _episodes[agentId].size();
@@ -293,7 +296,7 @@ void Agent::attendAgent(size_t agentId)
       if (_trainingLastReward > _trainingBestReward)
       {
         _trainingBestReward = _trainingLastReward;
-        _trainingBestEpisodeId = _agents[agentId]["Sample Id"];
+        _trainingBestEpisodeId = episodeId;
         _trainingBestPolicy = _agents[agentId]["Policy Hyperparameters"];
       }
 
@@ -313,7 +316,7 @@ void Agent::attendAgent(size_t agentId)
         if (_testingAverageReward > _testingBestAverageReward)
         {
           _testingBestAverageReward = _testingAverageReward;
-          _testingBestEpisodeId = _agents[agentId]["Sample Id"];
+          _testingBestEpisodeId = episodeId;
           _testingBestPolicy = _agents[agentId]["Policy Hyperparameters"];
         }
       }
@@ -339,7 +342,7 @@ void Agent::attendAgent(size_t agentId)
   _generationAgentAttendingTime += std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - beginTime).count(); // Profiling
 }
 
-void Agent::processEpisode(std::vector<knlohmann::json> &episode)
+void Agent::processEpisode(size_t episodeId, std::vector<knlohmann::json> &episode)
 {
   /*********************************************************************
   * Adding episode's experiences into the replay memory
@@ -352,10 +355,6 @@ void Agent::processEpisode(std::vector<knlohmann::json> &episode)
   {
     // Storage for new experience
     experience_t e;
-
-    // Creating caches for the new experience
-    e.cache.setMaxAge(_cachePersistence);
-    e.cache.setTimer(&_policyUpdateCount);
 
     // Getting state, action, reward, and whether it's terminal
     e.state = episode[expId]["State"].get<std::vector<float>>();
@@ -370,15 +369,16 @@ void Agent::processEpisode(std::vector<knlohmann::json> &episode)
       e.truncatedState = episode[expId]["Truncated State"].get<std::vector<float>>();
     }
 
+    // Storing Metadata coming from the agent
+    e.metadata = episode[expId]["Metadata"];
+
     // Updating metadata for prioritized minibatch selection
     e.metadata["Mini Batch"]["Priority"] = _experienceReplayMaxPriority;
     e.metadata["Mini Batch"]["Probability"] = 0.0;
 
-    // Storing policy
-    e.policy = episode[expId]["Policy"];
-
-    // Updating experience's importance weight in policy data. Initially assumed to be 1.0 because its freshly produced
-    e.policy["Importance Weight"] = 1.0f;
+    // Storing Episode information
+    e.metadata["Episode Id"] = episodeId;
+    e.metadata["Episode Position"] = expId;
 
     // Keeping statistics
     cumulativeReward += e.reward;
@@ -409,9 +409,6 @@ void Agent::processEpisode(std::vector<knlohmann::json> &episode)
     // Calculating the state value function of the truncated state
     float truncatedV = stateValueFunction(expTruncatedStateSequence);
 
-    // Storing calculated value in the cache, for future access
-    _experienceReplay[endId].cache.set("Terminal State Value", truncatedV);
-
     // Adding truncated state value to the retrace value
     retV += _discountFactor * truncatedV;
   }
@@ -423,8 +420,11 @@ void Agent::processEpisode(std::vector<knlohmann::json> &episode)
     retV = _discountFactor * retV + _experienceReplay[expId].reward;
 
     // Setting initial retrace value in the experience's cache
-    _experienceReplay[expId].policy["State Value"] = retV;
-    _experienceReplay[expId].cache.set("Retrace Value", retV);
+    _experienceReplay[expId].metadata["State Value"] = retV;
+    _experienceReplay[expId].metadata["Retrace Value"] = retV;
+
+    // Updating experience's importance weight. Initially assumed to be 1.0 because its freshly produced
+    _experienceReplay[expId].metadata["Importance Weight"] = 1.0f;
   }
 
   /*********************************************************************
@@ -452,12 +452,11 @@ void Agent::processEpisode(std::vector<knlohmann::json> &episode)
   size_t offPolicyCount = 0;
 
   // Count off-policy experiences
-#pragma omp parallel for reduction(+ \
-                                   : offPolicyCount)
+  #pragma omp parallel for reduction(+ : offPolicyCount)
   for (size_t expId = 0; expId < expCount; expId++)
   {
     // Getting the last calculated value of the experience's importance weight. We can tolerate this approximation.
-    float expImportanceWeight = _experienceReplay[expId].policy["Importance Weight"];
+    float expImportanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
 
     // It is off policy if it is outside the [1/cutoff, cutoff] region
     if ((expImportanceWeight < (1.0f / _experienceReplayOffPolicyCurrentCutoff)) ||
@@ -543,6 +542,35 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
       miniBatch[batchIdx++] = std::floor(_uniformGenerator->getRandomNumber() * (float)(_experienceReplay.size() - 1));
   }
 
+  // Update metadata for the minibatch experiences
+  #pragma omp parallel for schedule(dynamic, 1)
+  for (size_t i = 0; i < size; i++)
+   updateExperienceMetadata(miniBatch[i]);
+
+  // Selecting experiences, such that only one (the most advanced) per unique episode remains
+  std::map<size_t, size_t> episodeMaxExperienceAge;
+  for (size_t i = 0; i < size; i++)
+  {
+   size_t experienceId = miniBatch[i];
+   size_t episodeId =  _experienceReplay[experienceId].metadata["Episode Id"];
+   size_t episodePos = _experienceReplay[experienceId].metadata["Episode Position"];
+   size_t curMaxPosition = episodeMaxExperienceAge.find(episodeId) == episodeMaxExperienceAge.end() ? 0 : episodeMaxExperienceAge[episodeId];
+   if (episodePos >= curMaxPosition) episodeMaxExperienceAge[episodeId] = episodePos;
+  }
+
+  std::vector<size_t> experienceRetraceIds;
+  for (size_t i = 0; i < size; i++)
+  {
+   size_t experienceId = miniBatch[i];
+   size_t episodeId =  _experienceReplay[experienceId].metadata["Episode Id"];
+   size_t episodePos = _experienceReplay[experienceId].metadata["Episode Position"];
+   size_t curMaxPosition = episodeMaxExperienceAge[episodeId];
+   if (curMaxPosition == episodePos) experienceRetraceIds.push_back(experienceId);
+  }
+
+  #pragma omp parallel for schedule(dynamic, 1)
+  for (size_t i = 0; i < experienceRetraceIds.size(); i++)  retraceFunction(experienceRetraceIds[i]);
+
   return miniBatch;
 }
 
@@ -573,30 +601,19 @@ size_t Agent::getTimeSequenceStartExpId(size_t expId)
 float Agent::retraceFunction(size_t expId)
 {
   // Finding last experience in the episode that corresponds to expId
-  ssize_t startId = expId;
-  ssize_t endId = startId;
-  while (_experienceReplay[endId].termination == e_nonTerminal) endId++;
+  ssize_t endId = expId;
+  ssize_t startId = endId;
+  while (_experienceReplay[startId].metadata["Experience Position"] > 0 && startId > 0) startId--;
 
   // Storage for the retrace value
   float retV = 0.0f;
 
-  // Checking in cache, whether the state value was obtained before
-  for (ssize_t curId = startId; curId <= endId; curId++)
-    if (_experienceReplay[curId].cache.contains("Retrace Value"))
-    {
-      // Getting the retrace value from cache
-      retV = _experienceReplay[curId].cache.get("Retrace Value");
-
-      // Starting from the experience before the found experience
-      endId = curId - 1;
-    }
-
-  // If we found it for the initial experience, return immediately
-  if (endId < startId) return retV;
-
   // If it was a truncated episode, add the value function for the terminal state to retV
-  if (_experienceReplay[endId].termination == e_truncated)
+  if (_experienceReplay[expId].termination == e_truncated)
     retV = stateValueFunction(getTruncatedStateTimeSequence(endId));
+
+  if (_experienceReplay[expId].termination == e_nonTerminal)
+    retV = _experienceReplay[expId + 1].metadata["Retrace Value"];
 
   // Now iterating backwards to calculate the rest of vTbc
   for (ssize_t curId = endId; curId >= startId; curId--)
@@ -607,10 +624,10 @@ float Agent::retraceFunction(size_t expId)
     auto expAction = _experienceReplay[curId].action;
 
     // Calculating state value function
-    float curV = _experienceReplay[curId].policy["State Value"];
+    float curV = _experienceReplay[curId].metadata["State Value"];
 
     // Calculating importance weight
-    float importanceWeight = _experienceReplay[curId].policy["Importance Weight"];
+    float importanceWeight = _experienceReplay[curId].metadata["Importance Weight"];
 
     // Truncate importance weight
     float truncatedImportanceWeight = std::min(1.0f, importanceWeight);
@@ -619,7 +636,7 @@ float Agent::retraceFunction(size_t expId)
     retV = curV + truncatedImportanceWeight * (curReward + _discountFactor * retV - curV);
 
     // Storing retrace value into the experience's cache
-    _experienceReplay[curId].cache.set("Retrace Value", retV);
+    _experienceReplay[curId].metadata["Retrace Value"] = retV;
   }
 
   // Returning retrace value
@@ -726,11 +743,7 @@ void Agent::serializeExperienceReplay()
     stateJson["Experience Replay"][i]["Reward"] = _experienceReplay[i].reward;
     stateJson["Experience Replay"][i]["Termination"] = _experienceReplay[i].termination;
     stateJson["Experience Replay"][i]["Truncated State"] = _experienceReplay[i].truncatedState;
-    stateJson["Experience Replay"][i]["Policy"] = _experienceReplay[i].policy;
     stateJson["Experience Replay"][i]["Metadata"] = _experienceReplay[i].metadata;
-    stateJson["Experience Replay"][i]["Cache"]["Keys"] = _experienceReplay[i].cache.getKeys();
-    stateJson["Experience Replay"][i]["Cache"]["Values"] = _experienceReplay[i].cache.getValues();
-    stateJson["Experience Replay"][i]["Cache"]["Times"] = _experienceReplay[i].cache.getTimes();
   }
 
   // Storing training/testing policies
@@ -783,26 +796,9 @@ void Agent::deserializeExperienceReplay()
     e.reward = stateJson["Experience Replay"][i]["Reward"].get<float>();
     e.termination = stateJson["Experience Replay"][i]["Termination"].get<termination_t>();
     e.truncatedState = stateJson["Experience Replay"][i]["Truncated State"].get<std::vector<float>>();
-    e.policy = stateJson["Experience Replay"][i]["Policy"];
     e.metadata = stateJson["Experience Replay"][i]["Metadata"];
 
     _experienceReplay.add(e);
-  }
-
-  // Now updating the cache for every experience
-  for (size_t i = 0; i < _experienceReplay.size(); i++)
-  {
-    // Creating caches for the new experience
-    _experienceReplay[i].cache.setMaxAge(_cachePersistence);
-    _experienceReplay[i].cache.setTimer(&_policyUpdateCount);
-
-    for (size_t c = 0; c < stateJson["Experience Replay"][i]["Cache"]["Keys"].size(); c++)
-    {
-      auto key = stateJson["Experience Replay"][i]["Cache"]["Keys"][c].get<std::string>();
-      auto val = stateJson["Experience Replay"][i]["Cache"]["Values"][c].get<float>();
-      auto time = stateJson["Experience Replay"][i]["Cache"]["Times"][c].get<size_t>();
-      _experienceReplay[i].cache.set(key, val, time);
-    }
   }
 
   // Restoring training/testing policies

--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -563,8 +563,10 @@ std::vector<size_t> Agent::generateMiniBatch(size_t miniBatchSize)
 
     // Get state value function. Some algorithms return it as part of the policy
     float V = 0.0f;
-    if (isDefined(curPolicy, "State Value"))  V = curPolicy["State Value"].get<float>();
-    else V = stateValueFunction(expStateSequence);
+    if (isDefined(curPolicy, "State Value"))
+      V = curPolicy["State Value"].get<float>();
+    else
+      V = stateValueFunction(expStateSequence);
 
     // Compute importance weight
     float importanceWeight = calculateImportanceWeight(expAction, curPolicy, expPolicy);
@@ -591,28 +593,32 @@ std::vector<size_t> Agent::generateMiniBatch(size_t miniBatchSize)
 
   // Selecting experiences, such that only one (the most advanced) per unique episode remains
   std::map<size_t, size_t> episodeMaxExperienceAge;
+  std::map<size_t, size_t> episodeMaxExperienceId;
+
   for (size_t i = 0; i < miniBatchSize; i++)
   {
     size_t experienceId = miniBatch[i];
     size_t episodeId = _experienceReplay[experienceId].episodeId;
     size_t episodePos = _experienceReplay[experienceId].episodePos;
     size_t curMaxPosition = episodeMaxExperienceAge.find(episodeId) == episodeMaxExperienceAge.end() ? 0 : episodeMaxExperienceAge[episodeId];
-    if (episodePos >= curMaxPosition) episodeMaxExperienceAge[episodeId] = episodePos;
+
+    // If this is a new oldest experience in the episode, store it's position and id
+    if (episodePos >= curMaxPosition)
+    {
+      episodeMaxExperienceAge[episodeId] = episodePos;
+      episodeMaxExperienceId[episodeId] = experienceId;
+    }
   }
 
+  // Passing the content of the map to a vector
   std::vector<size_t> experienceRetraceIds;
-  for (size_t i = 0; i < miniBatchSize; i++)
-  {
-    size_t experienceId = miniBatch[i];
-    size_t episodeId = _experienceReplay[experienceId].episodeId;
-    size_t episodePos = _experienceReplay[experienceId].episodePos;
-    size_t curMaxPosition = episodeMaxExperienceAge[episodeId];
-    if (curMaxPosition == episodePos) experienceRetraceIds.push_back(experienceId);
-  }
+  for (const auto &expId : episodeMaxExperienceId) experienceRetraceIds.push_back(expId.first);
 
+// Running all experiences in parallel
 #pragma omp parallel for schedule(dynamic, 1)
   for (size_t i = 0; i < experienceRetraceIds.size(); i++) retraceFunction(experienceRetraceIds[i]);
 
+  // Returning generated minibatch
   return miniBatch;
 }
 

--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -644,10 +644,12 @@ size_t Agent::getTimeSequenceStartExpId(size_t expId)
 
 float Agent::retraceFunction(size_t expId)
 {
-  // Finding last experience in the episode that corresponds to expId
+  // Finding the earliest experience corresponding to the same episode as this experience
   ssize_t endId = expId;
-  ssize_t startId = endId;
-  while (_experienceReplay[startId].episodePos > 0 && startId > 0) startId--;
+  ssize_t startId = endId - _experienceReplay[endId].episodePos;
+
+  // If the starting experience has already been discarded, take the earliest one that still remains
+  if (startId < 0) startId = 0;
 
   // Storage for the retrace value
   float retV = 0.0f;
@@ -797,7 +799,7 @@ void Agent::serializeExperienceReplay()
     stateJson["Experience Replay"][i]["Metadata"] = _experienceReplay[i].metadata;
   }
 
-  //  // Storing training/testing policies
+  // Storing training/testing policies
   stateJson["Training"]["Current Policy"] = _trainingCurrentPolicy;
   stateJson["Training"]["Best Policy"] = _trainingBestPolicy;
   stateJson["Testing"]["Best Policy"] = _testingBestPolicy;

--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -377,8 +377,8 @@ void Agent::processEpisode(size_t episodeId, std::vector<knlohmann::json> &episo
     e.metadata["Mini Batch"]["Probability"] = 0.0;
 
     // Storing Episode information
-    e.metadata["Episode Id"] = episodeId;
-    e.metadata["Episode Position"] = expId;
+    e.episodeId = episodeId;
+    e.episodePos = expId;
 
     // Keeping statistics
     cumulativeReward += e.reward;
@@ -420,11 +420,11 @@ void Agent::processEpisode(size_t episodeId, std::vector<knlohmann::json> &episo
     retV = _discountFactor * retV + _experienceReplay[expId].reward;
 
     // Setting initial retrace value in the experience's cache
-    _experienceReplay[expId].metadata["State Value"] = retV;
-    _experienceReplay[expId].metadata["Retrace Value"] = retV;
+    _experienceReplay[expId].stateValue = retV;
+    _experienceReplay[expId].retraceValue = retV;
 
     // Updating experience's importance weight. Initially assumed to be 1.0 because its freshly produced
-    _experienceReplay[expId].metadata["Importance Weight"] = 1.0f;
+    _experienceReplay[expId].importanceWeight = 1.0f;
   }
 
   /*********************************************************************
@@ -442,7 +442,7 @@ void Agent::processEpisode(size_t episodeId, std::vector<knlohmann::json> &episo
   if (startEpisodeId < 0) startEpisodeId = 0;
   for (ssize_t e = startEpisodeId; e <= endEpisodeId; e++)
     _trainingAverageReward += _trainingRewardHistory[e];
-  _trainingAverageReward /= (float)(endEpisodeId-startEpisodeId+1);
+  _trainingAverageReward /= (float)(endEpisodeId - startEpisodeId + 1);
 
   /*********************************************************************
    * Updating off-policy ratio
@@ -451,12 +451,13 @@ void Agent::processEpisode(size_t episodeId, std::vector<knlohmann::json> &episo
   size_t expCount = _experienceReplay.size();
   size_t offPolicyCount = 0;
 
-  // Count off-policy experiences
-  #pragma omp parallel for reduction(+ : offPolicyCount)
+// Count off-policy experiences
+#pragma omp parallel for reduction(+ \
+                                   : offPolicyCount)
   for (size_t expId = 0; expId < expCount; expId++)
   {
     // Getting the last calculated value of the experience's importance weight. We can tolerate this approximation.
-    float expImportanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
+    float expImportanceWeight = _experienceReplay[expId].importanceWeight;
 
     // It is off policy if it is outside the [1/cutoff, cutoff] region
     if ((expImportanceWeight < (1.0f / _experienceReplayOffPolicyCurrentCutoff)) ||
@@ -546,42 +547,42 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
    * Updating experience's metadata
    *********************************************/
 
-  #pragma omp parallel for schedule(dynamic, 1)
+#pragma omp parallel for schedule(dynamic, 1)
   for (size_t i = 0; i < size; i++)
   {
-   auto expId = miniBatch[i];
+    auto expId = miniBatch[i];
 
-   // Get state, action, mean, Sigma for this experience
-   auto expStateSequence = getStateTimeSequence(expId);
-   auto expAction = _experienceReplay[expId].action;
-   auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
+    // Get state, action, mean, Sigma for this experience
+    auto expStateSequence = getStateTimeSequence(expId);
+    auto expAction = _experienceReplay[expId].action;
+    auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
 
-   // Running policy for the current state
-   auto curPolicy = runPolicy(expStateSequence);
+    // Running policy for the current state
+    auto curPolicy = runPolicy(expStateSequence);
 
-   // Get state value function. Some algorithms return it as part of the policy
-   float V = 0.0f;
-   if (isDefined(curPolicy, "State Value"))
-    V = curPolicy["State Value"].get<float>();
-   else
-    V = stateValueFunction(expStateSequence);
+    // Get state value function. Some algorithms return it as part of the policy
+    float V = 0.0f;
+    if (isDefined(curPolicy, "State Value"))
+      V = curPolicy["State Value"].get<float>();
+    else
+      V = stateValueFunction(expStateSequence);
 
-   // Compute importance weight
-   float importanceWeight = calculateImportanceWeight(expAction, curPolicy, expPolicy);
+    // Compute importance weight
+    float importanceWeight = calculateImportanceWeight(expAction, curPolicy, expPolicy);
 
-   // If this is the truncated experience of an episode, then obtain truncated state value
-   float truncatedV = 0.0f;
-   if (_experienceReplay[expId].termination == e_truncated)
-    truncatedV = stateValueFunction(getTruncatedStateTimeSequence(expId));
+    // If this is the truncated experience of an episode, then obtain truncated state value
+    float truncatedV = 0.0f;
+    if (_experienceReplay[expId].termination == e_truncated)
+      truncatedV = stateValueFunction(getTruncatedStateTimeSequence(expId));
 
-   // Store computed information for use in retrace.
-   #pragma omp critical
-   {
-    _experienceReplay[expId].metadata["State Value"] = V;
-    if (_experienceReplay[expId].termination == e_truncated)  _experienceReplay[expId].metadata["Truncated State Value"] = truncatedV;
-    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
-    _experienceReplay[expId].metadata["Current Policy"] = curPolicy;
-   }
+// Store computed information for use in retrace.
+#pragma omp critical
+    {
+      _experienceReplay[expId].stateValue = V;
+      if (_experienceReplay[expId].termination == e_truncated) _experienceReplay[expId].truncatedStateValue = truncatedV;
+      _experienceReplay[expId].importanceWeight = importanceWeight;
+      _experienceReplay[expId].metadata["Current Policy"] = curPolicy;
+    }
   }
 
   /**************************************************
@@ -592,25 +593,25 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
   std::map<size_t, size_t> episodeMaxExperienceAge;
   for (size_t i = 0; i < size; i++)
   {
-   size_t experienceId = miniBatch[i];
-   size_t episodeId =  _experienceReplay[experienceId].metadata["Episode Id"];
-   size_t episodePos = _experienceReplay[experienceId].metadata["Episode Position"];
-   size_t curMaxPosition = episodeMaxExperienceAge.find(episodeId) == episodeMaxExperienceAge.end() ? 0 : episodeMaxExperienceAge[episodeId];
-   if (episodePos >= curMaxPosition) episodeMaxExperienceAge[episodeId] = episodePos;
+    size_t experienceId = miniBatch[i];
+    size_t episodeId = _experienceReplay[experienceId].episodeId;
+    size_t episodePos = _experienceReplay[experienceId].episodePos;
+    size_t curMaxPosition = episodeMaxExperienceAge.find(episodeId) == episodeMaxExperienceAge.end() ? 0 : episodeMaxExperienceAge[episodeId];
+    if (episodePos >= curMaxPosition) episodeMaxExperienceAge[episodeId] = episodePos;
   }
 
   std::vector<size_t> experienceRetraceIds;
   for (size_t i = 0; i < size; i++)
   {
-   size_t experienceId = miniBatch[i];
-   size_t episodeId =  _experienceReplay[experienceId].metadata["Episode Id"];
-   size_t episodePos = _experienceReplay[experienceId].metadata["Episode Position"];
-   size_t curMaxPosition = episodeMaxExperienceAge[episodeId];
-   if (curMaxPosition == episodePos) experienceRetraceIds.push_back(experienceId);
+    size_t experienceId = miniBatch[i];
+    size_t episodeId = _experienceReplay[experienceId].episodeId;
+    size_t episodePos = _experienceReplay[experienceId].episodePos;
+    size_t curMaxPosition = episodeMaxExperienceAge[episodeId];
+    if (curMaxPosition == episodePos) experienceRetraceIds.push_back(experienceId);
   }
 
-  #pragma omp parallel for schedule(dynamic, 1)
-  for (size_t i = 0; i < experienceRetraceIds.size(); i++)  retraceFunction(experienceRetraceIds[i]);
+#pragma omp parallel for schedule(dynamic, 1)
+  for (size_t i = 0; i < experienceRetraceIds.size(); i++) retraceFunction(experienceRetraceIds[i]);
 
   return miniBatch;
 }
@@ -644,17 +645,17 @@ float Agent::retraceFunction(size_t expId)
   // Finding last experience in the episode that corresponds to expId
   ssize_t endId = expId;
   ssize_t startId = endId;
-  while (_experienceReplay[startId].metadata["Episode Position"] > 0 && startId > 0) startId--;
+  while (_experienceReplay[startId].episodePos > 0 && startId > 0) startId--;
 
   // Storage for the retrace value
   float retV = 0.0f;
 
   // If it was a truncated episode, add the value function for the terminal state to retV
   if (_experienceReplay[expId].termination == e_truncated)
-    retV = _experienceReplay[expId].metadata["Truncated State Value"];
+    retV = _experienceReplay[expId].truncatedStateValue;
 
   if (_experienceReplay[expId].termination == e_nonTerminal)
-    retV = _experienceReplay[expId + 1].metadata["Retrace Value"];
+    retV = _experienceReplay[expId + 1].retraceValue;
 
   // Now iterating backwards to calculate the rest of vTbc
   for (ssize_t curId = endId; curId >= startId; curId--)
@@ -665,10 +666,10 @@ float Agent::retraceFunction(size_t expId)
     auto expAction = _experienceReplay[curId].action;
 
     // Calculating state value function
-    float curV = _experienceReplay[curId].metadata["State Value"];
+    float curV = _experienceReplay[curId].stateValue;
 
     // Calculating importance weight
-    float importanceWeight = _experienceReplay[curId].metadata["Importance Weight"];
+    float importanceWeight = _experienceReplay[curId].importanceWeight;
 
     // Truncate importance weight
     float truncatedImportanceWeight = std::min(1.0f, importanceWeight);
@@ -677,7 +678,7 @@ float Agent::retraceFunction(size_t expId)
     retV = curV + truncatedImportanceWeight * (curReward + _discountFactor * retV - curV);
 
     // Storing retrace value into the experience's cache
-    _experienceReplay[curId].metadata["Retrace Value"] = retV;
+    _experienceReplay[curId].retraceValue = retV;
   }
 
   // Returning retrace value
@@ -779,15 +780,22 @@ void Agent::serializeExperienceReplay()
   // Serializing agent's database into the JSON storage
   for (size_t i = 0; i < _experienceReplay.size(); i++)
   {
+    stateJson["Experience Replay"][i]["Episode Id"] = _experienceReplay[i].episodeId;
+    stateJson["Experience Replay"][i]["Episode Pos"] = _experienceReplay[i].episodePos;
     stateJson["Experience Replay"][i]["State"] = _experienceReplay[i].state;
     stateJson["Experience Replay"][i]["Action"] = _experienceReplay[i].action;
     stateJson["Experience Replay"][i]["Reward"] = _experienceReplay[i].reward;
-    stateJson["Experience Replay"][i]["Termination"] = _experienceReplay[i].termination;
+    stateJson["Experience Replay"][i]["State Value"] = _experienceReplay[i].stateValue;
+    stateJson["Experience Replay"][i]["Retrace Value"] = _experienceReplay[i].retraceValue;
+    stateJson["Experience Replay"][i]["Importance Weight"] = _experienceReplay[i].importanceWeight;
+    stateJson["Experience Replay"][i]["Is On Policy"] = _experienceReplay[i].isOnPolicy;
     stateJson["Experience Replay"][i]["Truncated State"] = _experienceReplay[i].truncatedState;
+    stateJson["Experience Replay"][i]["Truncated State Value"] = _experienceReplay[i].truncatedStateValue;
+    stateJson["Experience Replay"][i]["Termination"] = _experienceReplay[i].termination;
     stateJson["Experience Replay"][i]["Metadata"] = _experienceReplay[i].metadata;
   }
 
-//  // Storing training/testing policies
+  //  // Storing training/testing policies
   stateJson["Training"]["Current Policy"] = _trainingCurrentPolicy;
   stateJson["Training"]["Best Policy"] = _trainingBestPolicy;
   stateJson["Testing"]["Best Policy"] = _testingBestPolicy;
@@ -832,11 +840,18 @@ void Agent::deserializeExperienceReplay()
   for (size_t i = 0; i < stateJson["Experience Replay"].size(); i++)
   {
     experience_t e;
+    e.episodeId = stateJson["Experience Replay"][i]["Episode Id"].get<size_t>();
+    e.episodePos = stateJson["Experience Replay"][i]["Episode Pos"].get<size_t>();
     e.state = stateJson["Experience Replay"][i]["State"].get<std::vector<float>>();
     e.action = stateJson["Experience Replay"][i]["Action"].get<std::vector<float>>();
     e.reward = stateJson["Experience Replay"][i]["Reward"].get<float>();
-    e.termination = stateJson["Experience Replay"][i]["Termination"].get<termination_t>();
+    e.stateValue = stateJson["Experience Replay"][i]["State Value"].get<float>();
+    e.retraceValue = stateJson["Experience Replay"][i]["Retrace Value"].get<float>();
+    e.importanceWeight = stateJson["Experience Replay"][i]["Importance Weight"].get<float>();
+    e.isOnPolicy = stateJson["Experience Replay"][i]["Is On Policy"].get<bool>();
     e.truncatedState = stateJson["Experience Replay"][i]["Truncated State"].get<std::vector<float>>();
+    e.truncatedStateValue = stateJson["Experience Replay"][i]["Truncated State Value"].get<float>();
+    e.termination = stateJson["Experience Replay"][i]["Termination"].get<termination_t>();
     e.metadata = stateJson["Experience Replay"][i]["Metadata"];
 
     _experienceReplay.add(e);

--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -425,6 +425,7 @@ void Agent::processEpisode(size_t episodeId, std::vector<knlohmann::json> &episo
 
     // Updating experience's importance weight. Initially assumed to be 1.0 because its freshly produced
     _experienceReplay[expId].importanceWeight = 1.0f;
+    _experienceReplay[expId].isOnPolicy = true;
   }
 
   /*********************************************************************
@@ -582,6 +583,7 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
       if (_experienceReplay[expId].termination == e_truncated) _experienceReplay[expId].truncatedStateValue = truncatedV;
       _experienceReplay[expId].importanceWeight = importanceWeight;
       _experienceReplay[expId].metadata["Current Policy"] = curPolicy;
+      _experienceReplay[expId].isOnPolicy = (importanceWeight > (1.0f / _experienceReplayOffPolicyCurrentCutoff)) && (importanceWeight < _experienceReplayOffPolicyCurrentCutoff);
     }
   }
 

--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -494,14 +494,14 @@ void Agent::updateExperienceReplayProbabilities()
   }
 }
 
-std::vector<size_t> Agent::generateMiniBatch(size_t size)
+std::vector<size_t> Agent::generateMiniBatch(size_t miniBatchSize)
 {
   // Allocating storage for mini batch experiecne indexes
-  std::vector<size_t> miniBatch(size);
+  std::vector<size_t> miniBatch(miniBatchSize);
 
   if (_miniBatchStrategy == "Uniform")
   {
-    for (size_t i = 0; i < size; i++)
+    for (size_t i = 0; i < miniBatchSize; i++)
     {
       // Producing random (uniform) number for the selection of the experience
       float x = _uniformGenerator->getRandomNumber();
@@ -517,9 +517,9 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
   if (_miniBatchStrategy == "Prioritized")
   {
     // Allocating storage for uniform random numbers
-    auto pvalues = std::vector<float>(size);
+    auto pvalues = std::vector<float>(miniBatchSize);
 
-    for (size_t i = 0; i < size; i++)
+    for (size_t i = 0; i < miniBatchSize; i++)
       pvalues[i] = _uniformGenerator->getRandomNumber();
 
     // Sort selections ascending for traversal
@@ -531,7 +531,7 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
 
     // Sampling from multinomial distribution using inverse transform
     cumulativeProbability += _experienceReplay[0].metadata["Mini Batch"]["Probability"].get<float>();
-    while (batchIdx < size && expId < _experienceReplay.size())
+    while (batchIdx < miniBatchSize && expId < _experienceReplay.size())
     {
       if (cumulativeProbability > pvalues[batchIdx])
         miniBatch[batchIdx++] = expId;
@@ -540,7 +540,7 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
     }
 
     // Uniform fill if miniBatch not full due to numerical precision during probability accumulation (cumulative probability < 1)
-    while (batchIdx < size)
+    while (batchIdx < miniBatchSize)
       miniBatch[batchIdx++] = std::floor(_uniformGenerator->getRandomNumber() * (float)(_experienceReplay.size() - 1));
   }
 
@@ -549,7 +549,7 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
    *********************************************/
 
 #pragma omp parallel for schedule(dynamic, 1)
-  for (size_t i = 0; i < size; i++)
+  for (size_t i = 0; i < miniBatchSize; i++)
   {
     auto expId = miniBatch[i];
 
@@ -563,10 +563,8 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
 
     // Get state value function. Some algorithms return it as part of the policy
     float V = 0.0f;
-    if (isDefined(curPolicy, "State Value"))
-      V = curPolicy["State Value"].get<float>();
-    else
-      V = stateValueFunction(expStateSequence);
+    if (isDefined(curPolicy, "State Value"))  V = curPolicy["State Value"].get<float>();
+    else V = stateValueFunction(expStateSequence);
 
     // Compute importance weight
     float importanceWeight = calculateImportanceWeight(expAction, curPolicy, expPolicy);
@@ -593,7 +591,7 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
 
   // Selecting experiences, such that only one (the most advanced) per unique episode remains
   std::map<size_t, size_t> episodeMaxExperienceAge;
-  for (size_t i = 0; i < size; i++)
+  for (size_t i = 0; i < miniBatchSize; i++)
   {
     size_t experienceId = miniBatch[i];
     size_t episodeId = _experienceReplay[experienceId].episodeId;
@@ -603,7 +601,7 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
   }
 
   std::vector<size_t> experienceRetraceIds;
-  for (size_t i = 0; i < size; i++)
+  for (size_t i = 0; i < miniBatchSize; i++)
   {
     size_t experienceId = miniBatch[i];
     size_t episodeId = _experienceReplay[experienceId].episodeId;

--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -442,7 +442,7 @@ void Agent::processEpisode(size_t episodeId, std::vector<knlohmann::json> &episo
   if (startEpisodeId < 0) startEpisodeId = 0;
   for (ssize_t e = startEpisodeId; e <= endEpisodeId; e++)
     _trainingAverageReward += _trainingRewardHistory[e];
-  _trainingAverageReward /= (float)(_trainingAverageDepth);
+  _trainingAverageReward /= (float)(endEpisodeId-startEpisodeId+1);
 
   /*********************************************************************
    * Updating off-policy ratio
@@ -559,8 +559,12 @@ std::vector<size_t> Agent::generateMiniBatch(size_t size)
    // Running policy for the current state
    auto curPolicy = runPolicy(expStateSequence);
 
-   // Get state value function
-   auto V = stateValueFunction(expStateSequence);
+   // Get state value function. Some algorithms return it as part of the policy
+   float V = 0.0f;
+   if (isDefined(curPolicy, "State Value"))
+    V = curPolicy["State Value"].get<float>();
+   else
+    V = stateValueFunction(expStateSequence);
 
    // Compute importance weight
    float importanceWeight = calculateImportanceWeight(expAction, curPolicy, expPolicy);

--- a/source/modules/solver/agent/agent._hpp
+++ b/source/modules/solver/agent/agent._hpp
@@ -2,7 +2,6 @@
 #define _KORALI_AGENT_HPP_
 
 #include "auxiliar/cbuffer.hpp"
-#include "auxiliar/kcache.hpp"
 #include "modules/problem/reinforcementLearning/reinforcementLearning.hpp"
 #include "modules/problem/supervisedLearning/supervisedLearning.hpp"
 #include "modules/solver/learner/deepSupervisor/deepSupervisor.hpp"
@@ -67,19 +66,9 @@ struct experience_t
   std::vector<float> truncatedState;
 
   /**
-   * @brief Contains information about the policy used to generate the action
-   */
-  knlohmann::json policy;
-
-  /**
    * @brief Contains any additional necessary information about the experience
    */
   knlohmann::json metadata;
-
-  /**
-   * @brief Provides a cached repository for pre-calculated values. It has an expiration threshold after which it's values should be re-calculated.
-   */
-  kCache<std::string, float, size_t> cache;
 };
 
 class Agent : public Solver
@@ -282,7 +271,7 @@ class Agent : public Solver
   * @brief Additional post-processing of episode after episode terminated.
   * @param episode A vector of experiences.
   */
-  void processEpisode(std::vector<knlohmann::json> &episode);
+  void processEpisode(size_t episodeId, std::vector<knlohmann::json> &episode);
 
   /**
   * @brief Updates probabilities of experiences stored based on their priority.
@@ -328,13 +317,6 @@ class Agent : public Solver
   * @return The time step vector of state/actions
   */
   std::vector<std::vector<float>> getStateActionTimeSequence(size_t expId);
-
-  /**
-  * @brief Calculates importance weights of experiences.
-  * @param miniBatch vector of experience indices.
-  * @return A vector with the importance weights corresponding to the experience indices.
-  */
-  std::vector<float> calculateImportanceWeights(std::vector<size_t> miniBatch);
 
   /**
    * @brief Returns the retrace value for the given experience
@@ -417,13 +399,6 @@ class Agent : public Solver
   virtual knlohmann::json getTrainingState() = 0;
 
   /**
-  * @brief Returns the value of importance weight for a given experience in the replay memory
-  * @param expId Index of the experience in the ER to calculate the importance weight for
-  * @return The experience's importance weight
-  */
-  virtual float getExperienceImportanceWeight(size_t expId) = 0;
-
-  /**
    * @brief Initializes the internal state of the policy
    */
   virtual void initializeAgent() = 0;
@@ -438,6 +413,8 @@ class Agent : public Solver
    * @param sample Sample on which the action and metadata will be stored
    */
   virtual void getAction(korali::Sample &sample) = 0;
+
+  virtual void updateExperienceMetadata(size_t expId) = 0;
 
   void runGeneration() override;
   void printGenerationAfter() override;

--- a/source/modules/solver/agent/agent._hpp
+++ b/source/modules/solver/agent/agent._hpp
@@ -318,6 +318,17 @@ class Agent : public Solver
   */
   std::vector<std::vector<float>> getStateActionTimeSequence(size_t expId);
 
+
+  /**
+   * @brief Calculates importance weight of current action from old and new policies
+   * @param action The action taken
+   * @param curPolicy The current policy
+   * @param oldPolicy The old policy, the one used for take the action in the first place
+   * @return The importance weight
+   */
+  virtual float calculateImportanceWeight(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy) = 0;
+
+
   /**
    * @brief Returns the retrace value for the given experience
    * @param expId The id (position within the replay memory) of the experience

--- a/source/modules/solver/agent/agent._hpp
+++ b/source/modules/solver/agent/agent._hpp
@@ -425,8 +425,6 @@ class Agent : public Solver
    */
   virtual void getAction(korali::Sample &sample) = 0;
 
-  virtual void updateExperienceMetadata(size_t expId) = 0;
-
   void runGeneration() override;
   void printGenerationAfter() override;
   void initialize() override;

--- a/source/modules/solver/agent/agent._hpp
+++ b/source/modules/solver/agent/agent._hpp
@@ -41,6 +41,16 @@ enum termination_t
 struct experience_t
 {
   /**
+  * @brief Episode that experience belongs to
+  */
+  size_t episodeId;
+
+  /**
+  * @brief Position within the episode of this experience
+  */
+  size_t episodePos;
+
+  /**
   * @brief Stores the state of the experience
   */
   std::vector<float> state;
@@ -56,14 +66,39 @@ struct experience_t
   float reward;
 
   /**
-   * @brief Specifies whether the experience is terminal (truncated or normal) or not.
+   * @brief Contains state value (V) estimation for the current state / policy combination
    */
-  termination_t termination;
+  float stateValue;
+
+  /**
+   * @brief Contains the result of the retrace (Vtbc) function for the currrent experience
+   */
+  float retraceValue;
+
+  /**
+   * @brief Contains the latest calculation of the experience's importance weight
+   */
+  float importanceWeight;
+
+  /**
+   * @brief Indicates whether the experience is on policy, given the specified off-policiness criteria
+   */
+  bool isOnPolicy;
 
   /**
    * @brief If this is a truncated terminal experience, the truncated state is also saved here
    */
   std::vector<float> truncatedState;
+
+  /**
+   * @brief If this is a truncated terminal experience, this contains the state value for that state
+   */
+  float truncatedStateValue;
+
+  /**
+   * @brief Specifies whether the experience is terminal (truncated or normal) or not.
+   */
+  termination_t termination;
 
   /**
    * @brief Contains any additional necessary information about the experience
@@ -269,7 +304,8 @@ class Agent : public Solver
 
   /**
   * @brief Additional post-processing of episode after episode terminated.
-  * @param episode A vector of experiences.
+  * @param episodeId The unique identifier of the provided episode
+  * @param episode A vector of experiences pertaining to the episode.
   */
   void processEpisode(size_t episodeId, std::vector<knlohmann::json> &episode);
 
@@ -318,7 +354,6 @@ class Agent : public Solver
   */
   std::vector<std::vector<float>> getStateActionTimeSequence(size_t expId);
 
-
   /**
    * @brief Calculates importance weight of current action from old and new policies
    * @param action The action taken
@@ -327,7 +362,6 @@ class Agent : public Solver
    * @return The importance weight
    */
   virtual float calculateImportanceWeight(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy) = 0;
-
 
   /**
    * @brief Returns the retrace value for the given experience

--- a/source/modules/solver/agent/agent._hpp
+++ b/source/modules/solver/agent/agent._hpp
@@ -316,10 +316,10 @@ class Agent : public Solver
 
   /**
   * @brief Generates an experience mini batch from the replay memory
-  * @param size Size of the mini batch to create
+  * @param miniBatchSize Size of the mini batch to create
   * @return A vector with the indexes to the experiences in the mini batch
   */
-  std::vector<size_t> generateMiniBatch(size_t size);
+  std::vector<size_t> generateMiniBatch(size_t miniBatchSize);
 
   /**
   * @brief Resets time sequence within the agent, to forget past actions from other episodes

--- a/source/modules/solver/agent/agent.config
+++ b/source/modules/solver/agent/agent.config
@@ -140,15 +140,9 @@
    "Type": "std::string",
    "Options": [
       { "Value": "Uniform", "Description": "Selects experiences from the replay memory with a randomly." },
-      { "Value": "Prioritized", "Description": "Prioritizes experiences according to their rank. See  Prioritized Experience Replay by Schaul et al. (2015)." },
-      { "Value": "Remember-and-Forget", "Description": "Selects experiences randomly, so long as their importance weight is above a given tolerance." }
+      { "Value": "Prioritized", "Description": "Prioritizes experiences according to their rank. See  Prioritized Experience Replay by Schaul et al. (2015)." }
      ],
    "Description": "Determines how to select experiences from the replay memory for mini batch creation."
-  },  
-  {
-   "Name": [ "Cache Persistence" ],
-   "Type": "size_t",
-   "Description": "Indicates for how many policy updates will pre-calculated values be persist in the experience cache."
   }
  ],
 
@@ -327,7 +321,6 @@
    "Optimizer": "AdaBelief",
    "Discount Factor": 0.99,
    "Mini Batch Strategy": "Uniform",
-   "Cache Persistence": 0,
    "Time Sequence Length": 1,
    
    "L2 Regularization": 

--- a/source/modules/solver/agent/continuous/DDPG/DDPG._cpp
+++ b/source/modules/solver/agent/continuous/DDPG/DDPG._cpp
@@ -1,0 +1,323 @@
+#include "engine.hpp"
+#include "modules/solver/agent/continuous/DDPG/DDPG.hpp"
+#include "sample/sample.hpp"
+#include <omp.h>
+
+namespace korali
+{
+namespace solver
+{
+namespace agent
+{
+namespace continuous
+{
+void DDPG::initializeAgent()
+{
+  // Initializing common discrete agent configuration
+  Continuous::initializeAgent();
+
+  /*********************************************************************
+  * State Value Function Learner
+  *********************************************************************/
+
+  _vExperiment["Problem"]["Type"] = "Supervised Learning";
+  _vExperiment["Problem"]["Max Timesteps"] = _timeSequenceLength;
+  _vExperiment["Problem"]["Training Batch Size"] = _miniBatchSize;
+  _vExperiment["Problem"]["Inference Batch Size"] = 1;
+  _vExperiment["Problem"]["Input"]["Size"] = _problem->_stateVectorSize;
+  _vExperiment["Problem"]["Solution"]["Size"] = 1;
+
+  _vExperiment["Solver"]["Type"] = "Learner/DeepSupervisor";
+  _vExperiment["Solver"]["Optimizer"] = _optimizer;
+  _vExperiment["Solver"]["Learning Rate"] = _learningRate;
+  _vExperiment["Solver"]["Loss Function"] = "Mean Squared Error";
+  _vExperiment["Solver"]["Steps Per Generation"] = 1;
+  _vExperiment["Solver"]["Neural Network"]["Engine"] = _neuralNetworkEngine;
+  _vExperiment["Solver"]["Neural Network"]["Hidden Layers"] = _neuralNetworkHiddenLayers;
+  _vExperiment["Solver"]["Output Weights Scaling"] = 0.001;
+
+  // Running initialization to verify that the configuration is correct
+  _vExperiment.initialize();
+  _vProblem = dynamic_cast<problem::SupervisedLearning *>(_vExperiment._problem);
+  _vLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_vExperiment._solver);
+
+  /*********************************************************************
+  * Advantage Function learner
+  *********************************************************************/
+
+  _qExperiment["Problem"]["Type"] = "Supervised Learning";
+  _qExperiment["Problem"]["Max Timesteps"] = _timeSequenceLength;
+  _qExperiment["Problem"]["Training Batch Size"] = _miniBatchSize;
+  _qExperiment["Problem"]["Inference Batch Size"] = 1;
+  _qExperiment["Problem"]["Input"]["Size"] = _problem->_stateVectorSize + _problem->_actionVectorSize;
+  _qExperiment["Problem"]["Solution"]["Size"] = 1;
+
+  _qExperiment["Solver"]["Type"] = "Learner/DeepSupervisor";
+  _qExperiment["Solver"]["Optimizer"] = _optimizer;
+  _qExperiment["Solver"]["Learning Rate"] = _learningRate * _advantageLearningRateScale;
+  _qExperiment["Solver"]["Loss Function"] = "Mean Squared Error";
+  _qExperiment["Solver"]["Steps Per Generation"] = 1;
+  _qExperiment["Solver"]["Neural Network"]["Engine"] = _neuralNetworkEngine;
+  _qExperiment["Solver"]["Neural Network"]["Hidden Layers"] = _neuralNetworkHiddenLayers;
+
+  // Running initialization to verify that the configuration is correct
+  _qExperiment.initialize();
+  _qProblem = dynamic_cast<problem::SupervisedLearning *>(_qExperiment._problem);
+  _qLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_qExperiment._solver);
+
+  /*********************************************************************
+  * Policy Learner
+  *********************************************************************/
+
+  _pExperiment["Problem"]["Type"] = "Supervised Learning";
+  _pExperiment["Problem"]["Max Timesteps"] = _timeSequenceLength;
+  _pExperiment["Problem"]["Training Batch Size"] = _miniBatchSize;
+  _pExperiment["Problem"]["Inference Batch Size"] = 1;
+  _pExperiment["Problem"]["Input"]["Size"] = _problem->_stateVectorSize;
+  _pExperiment["Problem"]["Solution"]["Size"] = _problem->_actionVectorSize;
+
+  _pExperiment["Solver"]["Type"] = "Learner/DeepSupervisor";
+  _pExperiment["Solver"]["Optimizer"] = _optimizer;
+  _pExperiment["Solver"]["Learning Rate"] = _learningRate * _policyLearningRateScale;
+  _pExperiment["Solver"]["Loss Function"] = "Direct Gradient";
+  _pExperiment["Solver"]["Steps Per Generation"] = 1;
+  _pExperiment["Solver"]["Neural Network"]["Engine"] = _neuralNetworkEngine;
+  _pExperiment["Solver"]["Neural Network"]["Hidden Layers"] = _neuralNetworkHiddenLayers;
+  _pExperiment["Solver"]["Output Weights Scaling"] = 0.001;
+
+  // Adding policy masks, with masks to normalize and rescale the output to fit the action's [lower, upper] bounds
+  for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+  {
+    size_t varIdx = _problem->_actionVectorIndexes[i];
+    auto lowerBound = _k->_variables[varIdx]->_lowerBound;
+    auto upperBound = _k->_variables[varIdx]->_upperBound;
+    float shift = (upperBound + lowerBound) * 0.5;
+    float scale = (upperBound - lowerBound) * 0.5;
+    float sigma = _k->_variables[varIdx]->_initialExplorationNoise;
+
+    // Checking correct noise configuration
+    if (sigma <= 0.0f) KORALI_LOG_ERROR("Provided initial noise (%f) for action variable %lu is not defined or negative.\n", sigma, varIdx);
+
+    _pExperiment["Solver"]["Neural Network"]["Output Layer"]["Scale"][i] = scale;
+    _pExperiment["Solver"]["Neural Network"]["Output Layer"]["Shift"][i] = shift;
+    _pExperiment["Solver"]["Neural Network"]["Output Layer"]["Tanh Mask"][i] = true;
+  }
+
+  // Running initialization to verify that the configuration is correct
+  _pExperiment.initialize();
+  _pProblem = dynamic_cast<problem::SupervisedLearning *>(_pExperiment._problem);
+  _pLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_pExperiment._solver);
+}
+
+float DDPG::stateValueFunction(const std::vector<std::vector<float>> &stateSequence)
+{
+  return _vLearner->getEvaluation({stateSequence})[0][0];
+}
+
+float DDPG::getActionAdvantage(const std::vector<std::vector<float>> &stateActionSequence)
+{
+  return _qLearner->getEvaluation({stateActionSequence})[0][0];
+}
+
+void DDPG::trainPolicy()
+{
+  // Creating minibatch for the critic update
+  auto miniBatchIndexes = generateMiniBatch(_miniBatchSize);
+
+#pragma omp parallel for schedule(dynamic, 1)
+  for (size_t b = 0; b < _miniBatchSize; b++)
+  {
+    /******************************************************************************************
+    * Gathering experience information
+    *******************************************************************************************/
+
+    // Getting index of current experiment
+    size_t expId = miniBatchIndexes[b];
+
+    // Get state, action and policy for this experience
+    auto expStateSequence = getStateTimeSequence(expId);
+    auto expStateActionSequence = getStateActionTimeSequence(expId);
+    auto expAction = _experienceReplay[expId].action;
+    auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
+
+    // Gathering metadata
+    float curV = _experienceReplay[expId].stateValue;
+    auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
+    float retV = _experienceReplay[expId].retraceValue;
+
+    // Gathering policy information
+    auto expMeans = expPolicy["Action Means"].get<std::vector<float>>();
+    auto expSigmas = expPolicy["Action Sigmas"].get<std::vector<float>>();
+    auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+    auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
+
+    /*****************************************
+    * Calculating Critic Gradients
+    *****************************************/
+
+    // Storage for the V+policy gradients
+    std::vector<float> vpGradients(1 + 2 * _problem->_actionVectorSize, 0.0f);
+
+    // Qret for terminal state is just reward
+    float retQ = _experienceReplay[expId].reward;
+
+    // Check whether experience is non-terminal
+    bool isNormal = _experienceReplay[expId].termination == e_nonTerminal;
+
+    // In this case add Vtbc
+    if (isNormal == true)
+    {
+      float nextExpVtbc = _experienceReplay[expId + 1].retraceValue;
+      retQ += _discountFactor * nextExpVtbc;
+    }
+
+    // Check whether experience is truncated
+    bool isTrucated = _experienceReplay[expId].termination == e_truncated;
+
+    // For truncated state add value
+    if (isTrucated == true)
+    {
+      float nextExpVtbc = _experienceReplay[expId].truncatedStateValue;
+      retQ += _discountFactor * nextExpVtbc;
+    }
+
+    _vProblem->_inputData[b] = expStateSequence;
+    _vProblem->_solutionData[b] = {retV};
+
+    _qProblem->_inputData[b] = expStateActionSequence;
+    _qProblem->_solutionData[b] = {retQ - curV};
+
+    /******************************************************************************************
+    * Calculating Policy Gradients
+    *******************************************************************************************/
+
+    // Storage for the policy gradients
+    std::vector<float> pGradients(_problem->_actionVectorSize, 0.0f);
+
+    // If it's on policy, we do calculate the policy gradients
+    if (_experienceReplay[expId].isOnPolicy)
+    {
+      // Storage for the DDPG and REFER gradients
+      std::vector<float> DDPGGradients(_problem->_actionVectorSize, 0.0f);
+
+      auto eval = _qLearner->getEvaluation({expStateActionSequence});
+      auto dataGradients = _qLearner->getDataGradients({expStateActionSequence}, {{{1.0f}}});
+
+      for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+        DDPGGradients[i] = dataGradients[0][_problem->_stateVectorSize + i];
+
+      // If the experiment if on-policy, we use it for the calculation of the gradients
+      for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+        pGradients[i] += _experienceReplayOffPolicyREFERBeta * DDPGGradients[i];
+    }
+
+    std::vector<float> referGradients(_problem->_actionVectorSize, 0.0f);
+
+    // Getting REFER gradients
+    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+      referGradients[i] = expMeans[i] - curMeans[i];
+
+    // Applying REFER gradients
+    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+      pGradients[i] += (1.0f - _experienceReplayOffPolicyREFERBeta) * referGradients[i];
+
+    // Adding means to the policy update
+    _pProblem->_inputData[b] = expStateSequence;
+    _pProblem->_solutionData[b] = pGradients;
+  }
+
+  // Updating learning rate for critic/policy learner guided by REFER
+  _vLearner->_learningRate = _currentLearningRate;
+  _qLearner->_learningRate = _currentLearningRate * _advantageLearningRateScale;
+  _pLearner->_learningRate = _currentLearningRate * _policyLearningRateScale;
+
+  // Running policy update
+  _vLearner->runGeneration();
+  _qLearner->runGeneration();
+
+  // Softly adapting the policy hyperparameters
+  auto curPolicyHyperparameters = _pLearner->getTrainingHyperparameters();
+  _pLearner->runGeneration();
+  auto newPolicyHyperparameters = _pLearner->getTrainingHyperparameters();
+  for (size_t i = 0; i < newPolicyHyperparameters.size(); i++)
+    newPolicyHyperparameters[i] = (1.0f - _policyAdoptionRate) * curPolicyHyperparameters[i] + _policyAdoptionRate * newPolicyHyperparameters[i];
+  _pLearner->setTrainingHyperparameters(newPolicyHyperparameters);
+  _pLearner->setInferenceHyperparameters(newPolicyHyperparameters);
+}
+
+knlohmann::json DDPG::runPolicy(const std::vector<std::vector<float>> &state)
+{
+  auto eval = _pLearner->getEvaluation({state})[0];
+
+  std::vector<float> actionMeans(_problem->_actionVectorSize);
+  std::vector<float> actionSigmas(_problem->_actionVectorSize);
+
+  for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+  {
+    size_t varIdx = _problem->_actionVectorIndexes[i];
+    float sigma = _k->_variables[varIdx]->_initialExplorationNoise;
+
+    // Checking correct noise configuration
+    if (sigma <= 0.0f) KORALI_LOG_ERROR("Provided initial noise (%f) for action variable %lu is not defined or negative.\n", sigma, varIdx);
+
+    actionMeans[i] = eval[i];
+    actionSigmas[i] = sigma;
+  }
+
+  knlohmann::json policy;
+  policy["Action Means"] = actionMeans;
+  policy["Action Sigmas"] = actionSigmas;
+  return policy;
+}
+
+knlohmann::json DDPG::getAgentPolicy()
+{
+  knlohmann::json hyperparameters;
+  hyperparameters["Policy"] = _pLearner->getInferenceHyperparameters();
+  return hyperparameters;
+}
+
+void DDPG::setAgentPolicy(const knlohmann::json &hyperparameters)
+{
+  auto policyHyperparameters = hyperparameters["Policy"].get<std::vector<float>>();
+  _pLearner->setInferenceHyperparameters(policyHyperparameters);
+}
+
+void DDPG::setTrainingState(const knlohmann::json &state)
+{
+  _qLearner->setTrainingHyperparameters(state["Q"]["Training"]);
+  _qLearner->setInferenceHyperparameters(state["Q"]["Inference"]);
+
+  _vLearner->setTrainingHyperparameters(state["V"]["Training"]);
+  _vLearner->setInferenceHyperparameters(state["V"]["Inference"]);
+
+  _pLearner->setTrainingHyperparameters(state["P"]["Training"]);
+  _pLearner->setInferenceHyperparameters(state["P"]["Inference"]);
+}
+
+knlohmann::json DDPG::getTrainingState()
+{
+  knlohmann::json state;
+
+  state["Q"]["Training"] = _qLearner->getTrainingHyperparameters();
+  state["Q"]["Inference"] = _qLearner->getInferenceHyperparameters();
+
+  state["V"]["Training"] = _vLearner->getTrainingHyperparameters();
+  state["V"]["Inference"] = _vLearner->getInferenceHyperparameters();
+
+  state["P"]["Training"] = _pLearner->getTrainingHyperparameters();
+  state["P"]["Inference"] = _pLearner->getInferenceHyperparameters();
+
+  return state;
+}
+
+void DDPG::printAgentInformation()
+{
+  _k->_logger->logInfo("Normal", " + Training Loss: [V = %.3e] [Q = %.3e] [P = %.3e]\n", _vLearner->_currentLoss, _qLearner->_currentLoss, _pLearner->_currentLoss);
+  _k->_logger->logInfo("Normal", " + Learning Rate: [V = %.3e] [Q = %.3e] [P = %.3e]\n", _vLearner->_learningRate, _qLearner->_learningRate, _pLearner->_learningRate);
+}
+
+} // namespace continuous
+} // namespace agent
+} // namespace solver
+} // namespace korali

--- a/source/modules/solver/agent/continuous/DDPG/DDPG._hpp
+++ b/source/modules/solver/agent/continuous/DDPG/DDPG._hpp
@@ -1,0 +1,86 @@
+#ifndef _KORALI_AGENT_CONTINUOUS_DDPG_HPP_
+#define _KORALI_AGENT_CONTINUOUS_DDPG_HPP_
+
+#include "modules/problem/reinforcementLearning/continuous/continuous.hpp"
+#include "modules/solver/agent/continuous/continuous.hpp"
+
+namespace korali
+{
+namespace solver
+{
+namespace agent
+{
+namespace continuous
+{
+class DDPG : public Continuous
+{
+  public:
+  /**
+   * @brief Pointer to training experiment's V(s) problem
+   */
+  problem::SupervisedLearning *_vProblem;
+
+  /**
+  * @brief Pointer to training experiment's V(s) critic learner
+  */
+  learner::DeepSupervisor *_vLearner;
+
+  /**
+   * @brief Korali experiment for the training of V(s)
+   */
+  korali::Experiment _vExperiment;
+
+  /**
+  * @brief Pointer to training experiment's Q(s,x) problem
+  */
+  problem::SupervisedLearning *_qProblem;
+
+  /**
+  * @brief Pointer to training experiment's Q(s,x) learner
+  */
+  learner::DeepSupervisor *_qLearner;
+
+  /**
+   * @brief Korali experiment for the training of Q(s,x)
+   */
+  korali::Experiment _qExperiment;
+
+  /**
+   * @brief Pointer to training experiment's P(s) problem
+   */
+  problem::SupervisedLearning *_pProblem;
+
+  /**
+  * @brief Pointer to training experiment's P(s) policy learner
+  */
+  learner::DeepSupervisor *_pLearner;
+
+  /**
+   * @brief Korali experiment for the training of P(s) policy
+   */
+  korali::Experiment _pExperiment;
+
+  /**
+   * @brief Returns the advantage value of the given state/action sequence
+   * @param stateActionSequence State/action sequence to evaluate
+   * @return The advantage value
+   */
+  float getActionAdvantage(const std::vector<std::vector<float>> &stateActionSequence);
+
+  knlohmann::json runPolicy(const std::vector<std::vector<float>> &stateSequence) override;
+  float stateValueFunction(const std::vector<std::vector<float>> &stateSequence) override;
+  knlohmann::json getAgentPolicy() override;
+  void setAgentPolicy(const knlohmann::json &hyperparameters) override;
+  void setTrainingState(const knlohmann::json &state) override;
+  knlohmann::json getTrainingState() override;
+  void trainPolicy() override;
+  void printAgentInformation() override;
+  void initializeAgent() override;
+};
+
+} // namespace continuous
+} // namespace agent
+} // namespace solver
+} // namespace korali
+
+#endif // _KORALI_AGENT_CONTINUOUS_DDPG_HPP_

--- a/source/modules/solver/agent/continuous/DDPG/DDPG.config
+++ b/source/modules/solver/agent/continuous/DDPG/DDPG.config
@@ -4,17 +4,17 @@
   {
     "Name": [ "Advantage", "Learning Rate Scale" ],
     "Type": "float",
+    "Description": "Indicates the relation of the advantage learning rate to the critic learning rate."
+  },
+  {
+    "Name": [ "Policy", "Learning Rate Scale" ],
+    "Type": "float",
     "Description": "Indicates the relation of the policy learning rate to the critic learning rate. This can be used to delay the learning of the policy."
   },
   {
-    "Name": [ "Policy", "Optimization Candidates" ],
+    "Name": [ "Policy", "Adoption Rate" ],
     "Type": "float",
-    "Description": "The number of candidates evaluated per generation CMAES."
-  },
-  {
-    "Name": [ "Policy", "Target Accuracy" ],
-    "Type": "float",
-    "Description": "Termination criteria for the CMAES optimizer. It represents the minimum difference between the maximum advantage value between two optimization steps."
+    "Description": "Smoothes the rate at which the new policy hyperparameters are adopted. (1-r)*oldH + r*newH."
   }
  ],
  
@@ -44,7 +44,8 @@
  
  "Module Defaults":
  {
-   "Advantage": { "Learning Rate Scale": 1.0 }
+  "Advantage": { "Learning Rate Scale": 1.0 },
+  "Policy": { "Learning Rate Scale": 1.0 }
  },
  
  "Variable Defaults":

--- a/source/modules/solver/agent/continuous/DDPG/README.rst
+++ b/source/modules/solver/agent/continuous/DDPG/README.rst
@@ -1,0 +1,13 @@
+******************************************
+Gradient-Free Policy Target (GFPT)
+******************************************
+
+Extension of DQN to continuous action domains. 
+The policy network :math:`\pi_\theta(s)` is trained to maximize the mean square error
+
+.. math::
+
+    L(\theta) = \mathbb{E}_s[(\pi_\theta(s)-\tilde a)^2]
+
+where :math:`\tilde a` is found by optimizing the deep Q-network using CMA-ES.
+

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
@@ -202,6 +202,7 @@ void GFPT::trainPolicy()
 
     // Get state, action, mean, Sigma for this experience
     auto expStateSequence = getStateTimeSequence(expId);
+    auto expStateActionSequence = getStateActionTimeSequence(expId);
     auto expAction = _experienceReplay[expId].action;
     auto expMeans = _experienceReplay[expId].metadata["Action Means"].get<std::vector<float>>();
     auto expSigmas = _experienceReplay[expId].metadata["Action Sigmas"].get<std::vector<float>>();

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
@@ -173,6 +173,11 @@ float GFPT::getActionAdvantage(const std::vector<std::vector<float>> &stateActio
   return _qLearner->getEvaluation({stateActionSequence})[0][0];
 }
 
+void GFPT::updateExperienceMetadata(size_t expId)
+{
+
+}
+
 void GFPT::trainPolicy()
 {
   // Creating minibatch for the critic update
@@ -192,32 +197,21 @@ void GFPT::trainPolicy()
     * Gathering experience information
     *******************************************************************************************/
 
-    // Selecting a uniformly random selected, yet not repeated experience
+    // Getting index of current experiment
     size_t expId = miniBatchIndexes[b];
 
-    // Getting experience's current state, state/action sequences
+    // Get state, action, mean, Sigma for this experience
     auto expStateSequence = getStateTimeSequence(expId);
-    auto expStateActionSequence = getStateActionTimeSequence(expId);
     auto expAction = _experienceReplay[expId].action;
+    auto expMeans = _experienceReplay[expId].metadata["Action Means"].get<std::vector<float>>();
+    auto expSigmas = _experienceReplay[expId].metadata["Action Sigmas"].get<std::vector<float>>();
 
-    // Getting Experience's policy distribution
-    auto expMeans = _experienceReplay[expId].policy["Action Means"].get<std::vector<float>>();
-    auto expSigmas = _experienceReplay[expId].policy["Action Sigmas"].get<std::vector<float>>();
-
-    // Updating action distributions for the current state
-    auto policy = runPolicy(expStateSequence);
-    auto curMeans = policy["Action Means"].get<std::vector<float>>();
-    auto curSigmas = policy["Action Sigmas"].get<std::vector<float>>();
-
-    // Re-computing importance weight for the experience
-    float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
-
-    // Get state value function
-    auto curV = stateValueFunction(expStateSequence);
-
-    // Important: store computed information for use in retrace.
-    _experienceReplay[expId].policy["State Value"] = curV;
-    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+    // Gathering metadata
+    float V = _experienceReplay[expId].metadata["State Value"];
+    auto curMeans = _experienceReplay[expId].metadata["Current Means"].get<std::vector<float>>();
+    auto curSigmas = _experienceReplay[expId].metadata["Current Sigmas"].get<std::vector<float>>();
+    float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
+    float expVtbc = _experienceReplay[expId].metadata["Retrace Value"];
 
     /*****************************************
     * Calculating Critic Gradients

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
@@ -16,49 +16,89 @@ void GFPT::initializeAgent()
   // Initializing common discrete agent configuration
   Continuous::initializeAgent();
 
-  /*********************************************************************
-  * State Value Function Learner
-  *********************************************************************/
+  _vpExperiment["Problem"]["Type"] = "Supervised Learning";
+  _vpExperiment["Problem"]["Max Timesteps"] = _timeSequenceLength;
+  _vpExperiment["Problem"]["Training Batch Size"] = _miniBatchSize;
+  _vpExperiment["Problem"]["Inference Batch Size"] = 1;
+  _vpExperiment["Problem"]["Input"]["Size"] = _problem->_stateVectorSize;
+  _vpExperiment["Problem"]["Solution"]["Size"] = 1 + 2 * _problem->_actionVectorSize;
 
-  _vExperiment["Problem"]["Type"] = "Supervised Learning";
-  _vExperiment["Problem"]["Max Timesteps"] = _timeSequenceLength;
-  _vExperiment["Problem"]["Training Batch Size"] = _miniBatchSize;
-  _vExperiment["Problem"]["Inference Batch Size"] = 1;
-  _vExperiment["Problem"]["Input"]["Size"] = _problem->_stateVectorSize;
-  _vExperiment["Problem"]["Solution"]["Size"] = 1;
+  _vpExperiment["Solver"]["Type"] = "Learner/DeepSupervisor";
+  _vpExperiment["Solver"]["Optimizer"] = _optimizer;
+  _vpExperiment["Solver"]["Learning Rate"] = _learningRate;
+  _vpExperiment["Solver"]["Loss Function"] = "Direct Gradient";
+  _vpExperiment["Solver"]["Steps Per Generation"] = 1;
+  _vpExperiment["Solver"]["Neural Network"]["Engine"] = _neuralNetworkEngine;
+  _vpExperiment["Solver"]["Neural Network"]["Hidden Layers"] = _neuralNetworkHiddenLayers;
+  _vpExperiment["Solver"]["Output Weights Scaling"] = 0.001;
 
-  _vExperiment["Solver"]["Type"] = "Learner/DeepSupervisor";
-  _vExperiment["Solver"]["Optimizer"] = _optimizer;
-  _vExperiment["Solver"]["L2 Regularization"]["Enabled"] = _l2RegularizationEnabled;
-  _vExperiment["Solver"]["L2 Regularization"]["Importance"] = _l2RegularizationImportance;
-  _vExperiment["Solver"]["Learning Rate"] = _currentLearningRate;
-  _vExperiment["Solver"]["Loss Function"] = "Mean Squared Error";
-  _vExperiment["Solver"]["Steps Per Generation"] = 1;
-  _vExperiment["Solver"]["Neural Network"]["Engine"] = _neuralNetworkEngine;
-  _vExperiment["Solver"]["Neural Network"]["Hidden Layers"] = _neuralNetworkHiddenLayers;
-  _vExperiment["Solver"]["Output Weights Scaling"] = 0.001;
+  // Masks to normalize and rescaling output to fit the action's [lower, upper] bounds (and sigmas/P)
+  _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Scale"][0] = 1.0f;
+  _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Shift"][0] = 0.0f;
+  _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Tanh Mask"][0] = false;
+  _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Softplus Mask"][0] = false;
+  _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Sigmoid Mask"][0] = false;
+
+  // Normalizing and rescaling output to fit the action's [lower, upper] bounds
+  for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+  {
+    size_t varIdx = _problem->_actionVectorIndexes[i];
+    auto lowerBound = _k->_variables[varIdx]->_lowerBound;
+    auto upperBound = _k->_variables[varIdx]->_upperBound;
+    float scale = (upperBound - lowerBound) * 0.5;
+    float shift = (upperBound + lowerBound) * 0.5;
+    float sigma = _k->_variables[varIdx]->_initialExplorationNoise;
+
+    // Checking correct noise configuration
+    if (sigma <= 0.0f) KORALI_LOG_ERROR("Provided initial noise (%f) for action variable %lu is not defined or negative.\n", sigma, varIdx);
+
+    // Tanh mask for Mean
+    _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Scale"][i + 1] = scale;
+    _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Shift"][i + 1] = shift;
+    _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Tanh Mask"][i + 1] = true;
+    _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Softplus Mask"][i + 1] = false;
+    _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Sigmoid Mask"][i + 1] = false;
+
+    if (_policyDistribution == "Normal")
+    {
+      // Softplus mask for Sigma
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Scale"][_problem->_actionVectorSize + i + 1] = sigma * 2.0f;
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Shift"][_problem->_actionVectorSize + i + 1] = 0.0f;
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Tanh Mask"][_problem->_actionVectorSize + i + 1] = false;
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Softplus Mask"][_problem->_actionVectorSize + i + 1] = true;
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Sigmoid Mask"][_problem->_actionVectorSize + i + 1] = false;
+    }
+
+    if (_policyDistribution == "Beta")
+    {
+      // Sigmoid in mask for Variance Coefficients in (0,1)
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Scale"][_problem->_actionVectorSize + i + 1] = sigma * 2.0f;
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Shift"][_problem->_actionVectorSize + i + 1] = 0.0f;
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Tanh Mask"][_problem->_actionVectorSize + i + 1] = false;
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Softplus Mask"][_problem->_actionVectorSize + i + 1] = false;
+      _vpExperiment["Solver"]["Neural Network"]["Output Layer"]["Sigmoid Mask"][_problem->_actionVectorSize + i + 1] = true;
+    }
+  }
 
   // Running initialization to verify that the configuration is correct
-  _vExperiment.initialize();
-  _vProblem = dynamic_cast<problem::SupervisedLearning *>(_vExperiment._problem);
-  _vLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_vExperiment._solver);
+  _vpExperiment.initialize();
+  _vpProblem = dynamic_cast<problem::SupervisedLearning *>(_vpExperiment._problem);
+  _vpLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_vpExperiment._solver);
 
   /*********************************************************************
   * Advantage Function learner
   *********************************************************************/
 
   _qExperiment["Problem"]["Type"] = "Supervised Learning";
-  _qExperiment["Problem"]["Max Timesteps"] = _timeSequenceLength;
+  _qExperiment["Problem"]["Max Timesteps"] = 1;
   _qExperiment["Problem"]["Training Batch Size"] = _miniBatchSize;
   _qExperiment["Problem"]["Inference Batch Size"] = 1;
-  _qExperiment["Problem"]["Input"]["Size"] = _problem->_stateVectorSize + _problem->_actionVectorSize;
+  _qExperiment["Problem"]["Input"]["Size"] = 1 + _problem->_stateVectorSize + _problem->_actionVectorSize;
   _qExperiment["Problem"]["Solution"]["Size"] = 1;
 
   _qExperiment["Solver"]["Type"] = "Learner/DeepSupervisor";
   _qExperiment["Solver"]["Optimizer"] = _optimizer;
-  _qExperiment["Solver"]["L2 Regularization"]["Enabled"] = _l2RegularizationEnabled;
-  _qExperiment["Solver"]["L2 Regularization"]["Importance"] = _l2RegularizationImportance;
-  _qExperiment["Solver"]["Learning Rate"] = _currentLearningRate * _advantageLearningRateScale;
+  _qExperiment["Solver"]["Learning Rate"] = _learningRate;
   _qExperiment["Solver"]["Loss Function"] = "Mean Squared Error";
   _qExperiment["Solver"]["Steps Per Generation"] = 1;
   _qExperiment["Solver"]["Neural Network"]["Engine"] = _neuralNetworkEngine;
@@ -70,51 +110,6 @@ void GFPT::initializeAgent()
   _qLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_qExperiment._solver);
 
   /*********************************************************************
-  * Policy Learner
-  *********************************************************************/
-
-  _pExperiment["Problem"]["Type"] = "Supervised Learning";
-  _pExperiment["Problem"]["Max Timesteps"] = _timeSequenceLength;
-  _pExperiment["Problem"]["Training Batch Size"] = _miniBatchSize;
-  _pExperiment["Problem"]["Inference Batch Size"] = 1;
-  _pExperiment["Problem"]["Input"]["Size"] = _problem->_stateVectorSize;
-  _pExperiment["Problem"]["Solution"]["Size"] = _problem->_actionVectorSize;
-
-  _pExperiment["Solver"]["Type"] = "Learner/DeepSupervisor";
-  _pExperiment["Solver"]["Optimizer"] = _optimizer;
-  _pExperiment["Solver"]["L2 Regularization"]["Enabled"] = _l2RegularizationEnabled;
-  _pExperiment["Solver"]["L2 Regularization"]["Importance"] = _l2RegularizationImportance;
-  _pExperiment["Solver"]["Learning Rate"] = _currentLearningRate * _policyLearningRateScale;
-  _pExperiment["Solver"]["Loss Function"] = "Direct Gradient";
-  _pExperiment["Solver"]["Steps Per Generation"] = 1;
-  _pExperiment["Solver"]["Neural Network"]["Engine"] = _neuralNetworkEngine;
-  _pExperiment["Solver"]["Neural Network"]["Hidden Layers"] = _neuralNetworkHiddenLayers;
-  _pExperiment["Solver"]["Output Weights Scaling"] = 0.001;
-
-  // Adding policy masks, with masks to normalize and rescale the output to fit the action's [lower, upper] bounds
-  for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-  {
-    size_t varIdx = _problem->_actionVectorIndexes[i];
-    auto lowerBound = _k->_variables[varIdx]->_lowerBound;
-    auto upperBound = _k->_variables[varIdx]->_upperBound;
-    float shift = (upperBound + lowerBound) * 0.5;
-    float scale = (upperBound - lowerBound) * 0.5;
-    float sigma = _k->_variables[varIdx]->_initialExplorationNoise;
-
-    // Checking correct noise configuration
-    if (sigma <= 0.0f) KORALI_LOG_ERROR("Provided initial noise (%f) for action variable %lu is not defined or negative.\n", sigma, varIdx);
-
-    _pExperiment["Solver"]["Neural Network"]["Output Layer"]["Scale"][i] = scale;
-    _pExperiment["Solver"]["Neural Network"]["Output Layer"]["Shift"][i] = shift;
-    _pExperiment["Solver"]["Neural Network"]["Output Layer"]["Tanh Mask"][i] = true;
-  }
-
-  // Running initialization to verify that the configuration is correct
-  _pExperiment.initialize();
-  _pProblem = dynamic_cast<problem::SupervisedLearning *>(_pExperiment._problem);
-  _pLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_pExperiment._solver);
-
-  /*********************************************************************
   * Initializing Action Optimizers (one per thread)
   *********************************************************************/
 
@@ -123,16 +118,6 @@ void GFPT::initializeAgent()
   {
     _actionOptimizers[threadIdx] = new korali::fCMAES(_problem->_actionVectorSize, _policyOptimizationCandidates);
     _actionOptimizers[threadIdx]->setSeed(_k->_randomSeed++);
-
-    // Initializing experiment with an initial zero set
-    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-    {
-      size_t varIdx = _problem->_actionVectorIndexes[i];
-      _actionOptimizers[threadIdx]->_lowerBounds[i] = _k->_variables[varIdx]->_lowerBound;
-      _actionOptimizers[threadIdx]->_upperBounds[i] = _k->_variables[varIdx]->_upperBound;
-      _actionOptimizers[threadIdx]->_initialMeans[i] = (_k->_variables[varIdx]->_lowerBound + _k->_variables[varIdx]->_upperBound) * 0.5;
-      _actionOptimizers[threadIdx]->_initialStandardDeviations[i] = (_k->_variables[varIdx]->_upperBound - _k->_variables[varIdx]->_lowerBound) * 0.5;
-    }
   }
 
   /*********************************************************************
@@ -151,21 +136,11 @@ void GFPT::initializeAgent()
     _batchOptimizationNetworks[threadIdx]->setConfiguration(nnConfig);
     _batchOptimizationNetworks[threadIdx]->initialize();
   }
-
-  /*********************************************************************
-  * Allocating storage for statistics
-  *********************************************************************/
-
-  if (_k->_currentGeneration == 0)
-  {
-    _statisticsAverageTargetSigmas.resize(_problem->_actionVectorSize, 0.0f);
-    _statisticsAverageActionSigmas.resize(_problem->_actionVectorSize, 0.0f);
-  }
 }
 
 float GFPT::stateValueFunction(const std::vector<std::vector<float>> &stateSequence)
 {
-  return _vLearner->getEvaluation({stateSequence})[0][0];
+  return _vpLearner->getEvaluation({stateSequence})[0][0];
 }
 
 float GFPT::getActionAdvantage(const std::vector<std::vector<float>> &stateActionSequence)
@@ -177,13 +152,6 @@ void GFPT::trainPolicy()
 {
   // Creating minibatch for the critic update
   auto miniBatchIndexes = generateMiniBatch(_miniBatchSize);
-
-  // [Statistics] Zeroing average diagonal covariance
-  for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-  {
-    _statisticsAverageActionSigmas[i] = 0.0f;
-    _statisticsAverageTargetSigmas[i] = 0.0f;
-  }
 
 #pragma omp parallel for schedule(dynamic, 1)
   for (size_t b = 0; b < _miniBatchSize; b++)
@@ -197,25 +165,27 @@ void GFPT::trainPolicy()
 
     // Get state, action and policy for this experience
     auto expStateSequence = getStateTimeSequence(expId);
-    auto expStateActionSequence = getStateActionTimeSequence(expId);
+    auto expState = _experienceReplay[expId].state;
     auto expAction = _experienceReplay[expId].action;
     auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
-    auto expMeans = expPolicy["Action Means"].get<std::vector<float>>();
-    auto expSigmas = expPolicy["Action Sigmas"].get<std::vector<float>>();
 
     // Gathering metadata
-    float V = _experienceReplay[expId].stateValue;
+    float curV = _experienceReplay[expId].stateValue;
     auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
-    float importanceWeight = _experienceReplay[expId].importanceWeight;
     float retV = _experienceReplay[expId].retraceValue;
 
-    // Gathering current policy information
+    // Gathering policy information
+    auto expMeans = expPolicy["Action Means"].get<std::vector<float>>();
+    auto expSigmas = expPolicy["Action Sigmas"].get<std::vector<float>>();
     auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
     auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
 
     /*****************************************
     * Calculating Critic Gradients
     *****************************************/
+
+    // Storage for the V+policy gradients
+    std::vector<float> vpGradients(1 + 2 * _problem->_actionVectorSize, 0.0f);
 
     // Qret for terminal state is just reward
     float retQ = _experienceReplay[expId].reward;
@@ -226,7 +196,7 @@ void GFPT::trainPolicy()
     // In this case add Vtbc
     if (isNormal == true)
     {
-      float nextExpVtbc = retraceFunction(expId + 1);
+      float nextExpVtbc = _experienceReplay[expId + 1].retraceValue;
       retQ += _discountFactor * nextExpVtbc;
     }
 
@@ -236,85 +206,64 @@ void GFPT::trainPolicy()
     // For truncated state add value
     if (isTrucated == true)
     {
-      // get truncated state
-      auto truncatedState = getTruncatedStateTimeSequence(expId);
-
-      // for truncated state, Vtbc == V - forward network
-      float nextExpVtbc = stateValueFunction(truncatedState);
-
-      // add value to Qret
+      float nextExpVtbc = _experienceReplay[expId].truncatedStateValue;
       retQ += _discountFactor * nextExpVtbc;
     }
 
-    _vProblem->_inputData[b] = expStateSequence;
-    _vProblem->_solutionData[b] = {retV};
+    vpGradients[0] = retV - curV;
 
-    _qProblem->_inputData[b] = expStateActionSequence;
-    _qProblem->_solutionData[b] = {retQ};
+    std::vector<float> qInput(1 + _problem->_stateVectorSize + _problem->_actionVectorSize);
+    qInput[0] = retV;
+    for (size_t i = 0; i < _problem->_stateVectorSize; i++) qInput[1 + i] = expState[i];
+    for (size_t i = 0; i < _problem->_actionVectorSize; i++) qInput[1 + _problem->_stateVectorSize + i] = expMeans[i];
+    _qProblem->_inputData[b] = {qInput};
+    _qProblem->_solutionData[b] = {retQ - curV};
 
     /*****************************************
-    * Calculating Policy Gradients
-    *****************************************/
+   * Calculating Policy Gradients
+   *****************************************/
 
-    // Storage for the v+policy gradients
-    std::vector<float> pGradients(_problem->_actionVectorSize, 0.0f);
-
-    // Storage for the GFPT and REFER gradients
-    std::vector<float> gfptGradients(_problem->_actionVectorSize, 0.0f);
-    std::vector<float> referGradients(_problem->_actionVectorSize, 0.0f);
-
-    // Optimizing best action for the selected experience
-    auto optResults = optimizeAction(expStateActionSequence, curMeans);
-    auto bstMeans = optResults["Best Means"].get<std::vector<float>>();
-    auto bstValue = optResults["Average Value"].get<float>();
-
-    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-      gfptGradients[i] = bstMeans[i] - curMeans[i];
-
-    // Getting REFER gradients
-    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-      referGradients[i] = expMeans[i] - curMeans[i];
-
-    // Checking whether the experience is on policy (i.e., it is within the [1/cutoff, cutoff] region)
-    bool isOnPolicy = (importanceWeight > (1.0f / _experienceReplayOffPolicyCurrentCutoff)) && (importanceWeight < _experienceReplayOffPolicyCurrentCutoff);
-
-    // If the experiment if on-policy, we use it for the calculation of the gradients
-    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-      if (isOnPolicy) pGradients[i] += _experienceReplayOffPolicyREFERBeta * gfptGradients[i];
-
-    // Applying REFER gradients
-    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-      pGradients[i] += (1.0f - _experienceReplayOffPolicyREFERBeta) * referGradients[i];
-
-// Computing statistics
-#pragma omp critical
-    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+    // If it's on policy, we do calculate the policy gradients
+    if (_experienceReplay[expId].isOnPolicy)
     {
-      _statisticsAverageTargetSigmas[i] += curSigmas[i];
-      _statisticsAverageActionSigmas[i] += curSigmas[i];
+      // Storage for the GFPT and REFER gradients
+      std::vector<float> gfptGradients(2 * _problem->_actionVectorSize, 0.0f);
+
+      auto actionValue = _qLearner->getEvaluation({{qInput}})[0][0];
+      auto importanceWeightGradients = calculateImportanceWeightGradient(expAction, curPolicy, expPolicy);
+
+      for (size_t i = 0; i < 2 * _problem->_actionVectorSize; i++)
+        gfptGradients[i] += actionValue * importanceWeightGradients[i];
+
+      // If the experiment if on-policy, we use it for the calculation of the gradients
+      for (size_t i = 0; i < 2 * _problem->_actionVectorSize; i++)
+        vpGradients[1 + i] += _experienceReplayOffPolicyREFERBeta * gfptGradients[i];
     }
 
+    // Getting REFER gradients
+    auto referGradients = calculateKLDivergenceGradient(expPolicy, curPolicy);
+
+    // Applying REFER gradients
+    for (size_t i = 0; i < 2 * _problem->_actionVectorSize; i++)
+      vpGradients[1 + i] -= (1.0f - _experienceReplayOffPolicyREFERBeta) * referGradients[i];
+
     // Adding means to the policy update
-    _pProblem->_inputData[b] = expStateSequence;
-    _pProblem->_solutionData[b] = pGradients;
+    _vpProblem->_inputData[b] = expStateSequence;
+    _vpProblem->_solutionData[b] = vpGradients;
   }
 
+  // Updating learning rate for critic/policy learner guided by REFER
+  _vpLearner->_learningRate = _currentLearningRate;
+  _qLearner->_learningRate = _currentLearningRate * _advantageLearningRateScale;
+
   // Running one generation of the optimization method with the given mini-batch
-  _vLearner->runGeneration();
+  _vpLearner->runGeneration();
   _qLearner->runGeneration();
-  _pLearner->runGeneration();
 
   // Updating batch evaluation network for the advantage function for CMAES steps
   auto aHyperparameters = _qLearner->getTrainingHyperparameters();
   for (size_t threadIdx = 0; threadIdx < _maxThreads; threadIdx++)
     _batchOptimizationNetworks[threadIdx]->setHyperparameters(aHyperparameters);
-
-  // Updating statistics
-  for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-  {
-    _statisticsAverageActionSigmas[i] /= (float)_miniBatchSize;
-    _statisticsAverageTargetSigmas[i] /= (float)_miniBatchSize;
-  }
 }
 
 knlohmann::json GFPT::optimizeAction(const std::vector<std::vector<float>> stateActionSequence, const std::vector<float> &curMeans)
@@ -335,16 +284,22 @@ knlohmann::json GFPT::optimizeAction(const std::vector<std::vector<float>> state
 
   // Setting initial action means from the current means
   actionOptimizer->_initialMeans = curMeans;
+  for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+  {
+    actionOptimizer->_initialStandardDeviations[i] = 0.50f;
+    actionOptimizer->_lowerBounds[i] = curMeans[i] - 0.25f;
+    actionOptimizer->_upperBounds[i] = curMeans[i] + 0.25f;
+  }
 
   // Resetting the state of the CMAES optimizer for the new batch
   actionOptimizer->reset();
 
   // Storage for the average of the advantage value from the last iteration
-  float prvAverageAdvantage = -std::numeric_limits<float>::infinity();
-  float curAverageAdvantage = 0;
+  float prvBestValue = -std::numeric_limits<float>::infinity();
+  float curBestValue = 0;
 
   // Run the CMAES experiment until the desired convergence
-  while (std::abs(curAverageAdvantage - prvAverageAdvantage) > _policyTargetAccuracy)
+  while (std::abs(curBestValue - prvBestValue) > _policyTargetAccuracy || actionOptimizer->_currentGeneration < 10)
   {
     // Asking CMAES to generate candidates
     actionOptimizer->prepareGeneration();
@@ -369,66 +324,54 @@ knlohmann::json GFPT::optimizeAction(const std::vector<std::vector<float>> state
       candidateEvaluations[i] = criticEvaluations[i][0];
 
     // Re-calculating average advantage value from the last generation
-    prvAverageAdvantage = curAverageAdvantage;
-    curAverageAdvantage = 0.0f;
-    for (size_t i = 0; i < _policyOptimizationCandidates; i++)
-      curAverageAdvantage += candidateEvaluations[i];
-    curAverageAdvantage /= (float)_policyOptimizationCandidates;
+    prvBestValue = curBestValue;
+    curBestValue = actionOptimizer->_bestEverValue;
 
     // Running one more CMAES iteration
     actionOptimizer->updateDistribution(candidateEvaluations);
     actionOptimizer->_currentGeneration++;
   }
 
-  // Updating learning rate for critic/policy learner guided by REFER
-  _vLearner->_learningRate = _currentLearningRate;
-  _qLearner->_learningRate = _currentLearningRate * _advantageLearningRateScale;
-  _pLearner->_learningRate = _currentLearningRate * _policyLearningRateScale;
-
   // Returning optimization results
   knlohmann::json result;
-  result["Best Means"] = actionOptimizer->_currentMean;
-  result["Average Value"] = curAverageAdvantage;
+  result["Best Means"] = actionOptimizer->_bestEverVariables;
+  result["Best Value"] = actionOptimizer->_bestEverValue;
 
   return result;
 }
 
 knlohmann::json GFPT::runPolicy(const std::vector<std::vector<float>> &state)
 {
-  auto eval = _pLearner->getEvaluation({state})[0];
+  // Forward the neural network for this state
+  auto evaluation = _vpLearner->getEvaluation({state})[0];
+  auto stateValue = evaluation[0];
 
   std::vector<float> actionMeans(_problem->_actionVectorSize);
   std::vector<float> actionSigmas(_problem->_actionVectorSize);
-
   for (size_t i = 0; i < _problem->_actionVectorSize; i++)
   {
-    size_t varIdx = _problem->_actionVectorIndexes[i];
-    float sigma = _k->_variables[varIdx]->_initialExplorationNoise;
-
-    // Checking correct noise configuration
-    if (sigma <= 0.0f) KORALI_LOG_ERROR("Provided initial noise (%f) for action variable %lu is not defined or negative.\n", sigma, varIdx);
-
-    actionMeans[i] = eval[i];
-    actionSigmas[i] = sigma;
+    actionMeans[i] = evaluation[i + 1];
+    actionSigmas[i] = evaluation[_problem->_actionVectorSize + i + 1];
   }
 
   knlohmann::json policy;
   policy["Action Means"] = actionMeans;
   policy["Action Sigmas"] = actionSigmas;
+  policy["State Value"] = stateValue;
   return policy;
 }
 
 knlohmann::json GFPT::getAgentPolicy()
 {
   knlohmann::json hyperparameters;
-  hyperparameters["Policy"] = _pLearner->getInferenceHyperparameters();
+  hyperparameters["Policy"] = _vpLearner->getInferenceHyperparameters();
   return hyperparameters;
 }
 
 void GFPT::setAgentPolicy(const knlohmann::json &hyperparameters)
 {
   auto policyHyperparameters = hyperparameters["Policy"].get<std::vector<float>>();
-  _pLearner->setInferenceHyperparameters(policyHyperparameters);
+  _vpLearner->setInferenceHyperparameters(policyHyperparameters);
 }
 
 void GFPT::setTrainingState(const knlohmann::json &state)
@@ -436,11 +379,8 @@ void GFPT::setTrainingState(const knlohmann::json &state)
   _qLearner->setTrainingHyperparameters(state["Q"]["Training"]);
   _qLearner->setInferenceHyperparameters(state["Q"]["Inference"]);
 
-  _vLearner->setTrainingHyperparameters(state["V"]["Training"]);
-  _vLearner->setInferenceHyperparameters(state["V"]["Inference"]);
-
-  _pLearner->setTrainingHyperparameters(state["P"]["Training"]);
-  _pLearner->setInferenceHyperparameters(state["P"]["Inference"]);
+  _vpLearner->setTrainingHyperparameters(state["VP"]["Training"]);
+  _vpLearner->setInferenceHyperparameters(state["VP"]["Inference"]);
 }
 
 knlohmann::json GFPT::getTrainingState()
@@ -450,20 +390,16 @@ knlohmann::json GFPT::getTrainingState()
   state["Q"]["Training"] = _qLearner->getTrainingHyperparameters();
   state["Q"]["Inference"] = _qLearner->getInferenceHyperparameters();
 
-  state["V"]["Training"] = _vLearner->getTrainingHyperparameters();
-  state["V"]["Inference"] = _vLearner->getInferenceHyperparameters();
-
-  state["P"]["Training"] = _pLearner->getTrainingHyperparameters();
-  state["P"]["Inference"] = _pLearner->getInferenceHyperparameters();
+  state["VP"]["Training"] = _vpLearner->getTrainingHyperparameters();
+  state["VP"]["Inference"] = _vpLearner->getInferenceHyperparameters();
 
   return state;
 }
 
 void GFPT::printAgentInformation()
 {
-  _k->_logger->logInfo("Normal", " + Training Loss: [V = %.3e] [Q = %.3e] [P = %.3e]\n", _vLearner->_currentLoss, _qLearner->_currentLoss, _pLearner->_currentLoss);
-  _k->_logger->logInfo("Normal", " + Average Action Sigma: [ Current ] -> [ Target ]\n");
-  for (size_t i = 0; i < _problem->_actionVectorSize; ++i) _k->_logger->logInfo("Normal", " +  [ %f ] -> [ %f ] \n", _statisticsAverageActionSigmas[i], _statisticsAverageTargetSigmas[i]);
+  _k->_logger->logInfo("Normal", " + Training Loss: [VP = %.3e] [Q = %.3e]\n", _vpLearner->_currentLoss, _qLearner->_currentLoss);
+  _k->_logger->logInfo("Normal", " + Learning Rate: [VP = %.3e] [Q = %.3e]\n", _vpLearner->_learningRate, _qLearner->_learningRate);
 }
 
 } // namespace continuous

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
@@ -173,11 +173,6 @@ float GFPT::getActionAdvantage(const std::vector<std::vector<float>> &stateActio
   return _qLearner->getEvaluation({stateActionSequence})[0][0];
 }
 
-void GFPT::updateExperienceMetadata(size_t expId)
-{
-
-}
-
 void GFPT::trainPolicy()
 {
   // Creating minibatch for the critic update
@@ -200,26 +195,27 @@ void GFPT::trainPolicy()
     // Getting index of current experiment
     size_t expId = miniBatchIndexes[b];
 
-    // Get state, action, mean, Sigma for this experience
+    // Get state, action and policy for this experience
     auto expStateSequence = getStateTimeSequence(expId);
     auto expStateActionSequence = getStateActionTimeSequence(expId);
     auto expAction = _experienceReplay[expId].action;
-    auto expMeans = _experienceReplay[expId].metadata["Action Means"].get<std::vector<float>>();
-    auto expSigmas = _experienceReplay[expId].metadata["Action Sigmas"].get<std::vector<float>>();
+    auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
+    auto expMeans = expPolicy["Action Means"].get<std::vector<float>>();
+    auto expSigmas = expPolicy["Action Sigmas"].get<std::vector<float>>();
 
     // Gathering metadata
     float V = _experienceReplay[expId].metadata["State Value"];
-    auto curMeans = _experienceReplay[expId].metadata["Current Means"].get<std::vector<float>>();
-    auto curSigmas = _experienceReplay[expId].metadata["Current Sigmas"].get<std::vector<float>>();
+    auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
     float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
-    float expVtbc = _experienceReplay[expId].metadata["Retrace Value"];
+    float retV = _experienceReplay[expId].metadata["Retrace Value"];
+
+    // Gathering current policy information
+    auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+    auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
 
     /*****************************************
     * Calculating Critic Gradients
     *****************************************/
-
-    // Using retrace to obtain a better estimation of the state value function
-    float retV = retraceFunction(expId);
 
     // Qret for terminal state is just reward
     float retQ = _experienceReplay[expId].reward;

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
@@ -204,10 +204,10 @@ void GFPT::trainPolicy()
     auto expSigmas = expPolicy["Action Sigmas"].get<std::vector<float>>();
 
     // Gathering metadata
-    float V = _experienceReplay[expId].metadata["State Value"];
+    float V = _experienceReplay[expId].stateValue;
     auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
-    float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
-    float retV = _experienceReplay[expId].metadata["Retrace Value"];
+    float importanceWeight = _experienceReplay[expId].importanceWeight;
+    float retV = _experienceReplay[expId].retraceValue;
 
     // Gathering current policy information
     auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
@@ -185,21 +185,21 @@ void GFPT::trainPolicy()
     *****************************************/
 
     // Storage for the V+policy gradients
-    std::vector<float> vpGradients(1 + 2*_problem->_actionVectorSize, 0.0f);
+    std::vector<float> vpGradients(1 + 2 * _problem->_actionVectorSize, 0.0f);
 
-     // This variable contains a target for the next state (if exists)
-     float nextV = 0.0f;
+    // This variable contains a target for the next state (if exists)
+    float nextV = 0.0f;
 
-     // If it's a non-terminal experience, add retrace value of next state
-     if (_experienceReplay[expId].termination == e_nonTerminal)
+    // If it's a non-terminal experience, add retrace value of next state
+    if (_experienceReplay[expId].termination == e_nonTerminal)
       nextV = _experienceReplay[expId + 1].retraceValue;
 
-     // For truncated episode experience, use state value of truncated state
-     if (_experienceReplay[expId].termination == e_truncated)
+    // For truncated episode experience, use state value of truncated state
+    if (_experienceReplay[expId].termination == e_truncated)
       nextV = _experienceReplay[expId].truncatedStateValue;
 
-     // Qret for terminal state is just reward
-     float retQ = _experienceReplay[expId].reward + _discountFactor * nextV;
+    // Qret for terminal state is just reward
+    float retQ = _experienceReplay[expId].reward + _discountFactor * nextV;
 
     vpGradients[0] = retV - curV;
 

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
@@ -185,30 +185,21 @@ void GFPT::trainPolicy()
     *****************************************/
 
     // Storage for the V+policy gradients
-    std::vector<float> vpGradients(1 + 2 * _problem->_actionVectorSize, 0.0f);
+    std::vector<float> vpGradients(1 + 2*_problem->_actionVectorSize, 0.0f);
 
-    // Qret for terminal state is just reward
-    float retQ = _experienceReplay[expId].reward;
+     // This variable contains a target for the next state (if exists)
+     float nextV = 0.0f;
 
-    // Check whether experience is non-terminal
-    bool isNormal = _experienceReplay[expId].termination == e_nonTerminal;
+     // If it's a non-terminal experience, add retrace value of next state
+     if (_experienceReplay[expId].termination == e_nonTerminal)
+      nextV = _experienceReplay[expId + 1].retraceValue;
 
-    // In this case add Vtbc
-    if (isNormal == true)
-    {
-      float nextExpVtbc = _experienceReplay[expId + 1].retraceValue;
-      retQ += _discountFactor * nextExpVtbc;
-    }
+     // For truncated episode experience, use state value of truncated state
+     if (_experienceReplay[expId].termination == e_truncated)
+      nextV = _experienceReplay[expId].truncatedStateValue;
 
-    // Check whether experience is truncated
-    bool isTrucated = _experienceReplay[expId].termination == e_truncated;
-
-    // For truncated state add value
-    if (isTrucated == true)
-    {
-      float nextExpVtbc = _experienceReplay[expId].truncatedStateValue;
-      retQ += _discountFactor * nextExpVtbc;
-    }
+     // Qret for terminal state is just reward
+     float retQ = _experienceReplay[expId].reward + _discountFactor * nextV;
 
     vpGradients[0] = retV - curV;
 

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._cpp
@@ -209,6 +209,16 @@ void GFPT::trainPolicy()
     auto curMeans = policy["Action Means"].get<std::vector<float>>();
     auto curSigmas = policy["Action Sigmas"].get<std::vector<float>>();
 
+    // Re-computing importance weight for the experience
+    float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
+
+    // Get state value function
+    auto curV = stateValueFunction(expStateSequence);
+
+    // Important: store computed information for use in retrace.
+    _experienceReplay[expId].policy["State Value"] = curV;
+    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+
     /*****************************************
     * Calculating Critic Gradients
     *****************************************/
@@ -273,10 +283,6 @@ void GFPT::trainPolicy()
     // Getting REFER gradients
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
       referGradients[i] = expMeans[i] - curMeans[i];
-
-    // Re-computing importance weight for the experiment and storing it into cache
-    float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
-    _experienceReplay[expId].cache.set("Importance Weight", importanceWeight);
 
     // Checking whether the experience is on policy (i.e., it is within the [1/cutoff, cutoff] region)
     bool isOnPolicy = (importanceWeight > (1.0f / _experienceReplayOffPolicyCurrentCutoff)) && (importanceWeight < _experienceReplayOffPolicyCurrentCutoff);

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._hpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._hpp
@@ -24,17 +24,17 @@ class GFPT : public Continuous
   /**
    * @brief Pointer to training experiment's V(s) problem
    */
-  problem::SupervisedLearning *_vProblem;
+  problem::SupervisedLearning *_vpProblem;
 
   /**
   * @brief Pointer to training experiment's V(s) critic learner
   */
-  learner::DeepSupervisor *_vLearner;
+  learner::DeepSupervisor *_vpLearner;
 
   /**
    * @brief Korali experiment for the training of V(s)
    */
-  korali::Experiment _vExperiment;
+  korali::Experiment _vpExperiment;
 
   /**
   * @brief Pointer to training experiment's Q(s,x) problem
@@ -50,21 +50,6 @@ class GFPT : public Continuous
    * @brief Korali experiment for the training of Q(s,x)
    */
   korali::Experiment _qExperiment;
-
-  /**
-   * @brief Pointer to training experiment's P(s) problem
-   */
-  problem::SupervisedLearning *_pProblem;
-
-  /**
-  * @brief Pointer to training experiment's P(s) policy learner
-  */
-  learner::DeepSupervisor *_pLearner;
-
-  /**
-   * @brief Korali experiment for the training of P(s) policy
-   */
-  korali::Experiment _pExperiment;
 
   /**
    * @brief Korali optimizer for finding the optimal action as per the critic. One instance per parallel thread.

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._hpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._hpp
@@ -93,7 +93,6 @@ class GFPT : public Continuous
    */
   knlohmann::json optimizeAction(const std::vector<std::vector<float>> stateActionSequence, const std::vector<float> &curMeans);
 
-  void updateExperienceMetadata(size_t expId) override;
   knlohmann::json runPolicy(const std::vector<std::vector<float>> &stateSequence) override;
   float stateValueFunction(const std::vector<std::vector<float>> &stateSequence) override;
   knlohmann::json getAgentPolicy() override;

--- a/source/modules/solver/agent/continuous/GFPT/GFPT._hpp
+++ b/source/modules/solver/agent/continuous/GFPT/GFPT._hpp
@@ -93,6 +93,7 @@ class GFPT : public Continuous
    */
   knlohmann::json optimizeAction(const std::vector<std::vector<float>> stateActionSequence, const std::vector<float> &curMeans);
 
+  void updateExperienceMetadata(size_t expId) override;
   knlohmann::json runPolicy(const std::vector<std::vector<float>> &stateSequence) override;
   float stateValueFunction(const std::vector<std::vector<float>> &stateSequence) override;
   knlohmann::json getAgentPolicy() override;

--- a/source/modules/solver/agent/continuous/NAF/NAF._cpp
+++ b/source/modules/solver/agent/continuous/NAF/NAF._cpp
@@ -100,13 +100,8 @@ void NAF::initializeAgent()
 float NAF::stateValueFunction(const std::vector<std::vector<float>> &state)
 {
   // Calculating V(s_i)
-  float v = _criticLearner->getEvaluation({state})[0][0];
-  return v;
-}
-
-void NAF::updateExperienceMetadata(size_t expId)
-{
- KORALI_LOG_ERROR("To-do.\n");
+  float V = _criticLearner->getEvaluation({state})[0][0];
+  return V;
 }
 
 void NAF::trainPolicy()
@@ -129,29 +124,24 @@ void NAF::trainPolicy()
 #pragma omp parallel for schedule(dynamic, 1)
   for (size_t b = 0; b < _miniBatchSize; b++)
   {
-    // Selecting a uniformly random selected, yet not repeated experience
+    // Getting index of current experiment
     size_t expId = miniBatchIndexes[b];
 
-    // Access experiences
+    // Get state, action and policy for this experience
     auto expStateSequence = getStateTimeSequence(expId);
     auto expAction = _experienceReplay[expId].action;
-    auto expMeans = _experienceReplay[expId].metadata["Action Means"].get<std::vector<float>>();
-    auto expSigmas = _experienceReplay[expId].metadata["Action Sigmas"].get<std::vector<float>>();
+    auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
 
-    // Forward the neural network for this state to get current means and sigmas and Value
-    auto policy = runPolicy(expStateSequence);
-    float V = policy["State Value"].get<float>();
-    auto curMeans = policy["Action Means"].get<std::vector<float>>();
-    auto curSigmas = policy["Action Sigmas"].get<std::vector<float>>();
-    auto curDiagP = policy["Diag P"].get<std::vector<float>>();
+    // Gathering metadata
+    float V = _experienceReplay[expId].metadata["State Value"];
+    auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
+    float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
+    float retV = _experienceReplay[expId].metadata["Retrace Value"];
 
-    // Compute importance weight
-    float importanceWeight = 0.0f;//calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
-    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
-
-    // Important: store computed information for use in retrace.
-    _experienceReplay[expId].metadata["State Value"] = V;
-    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
+    // Gathering current policy information
+    auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+    auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
+    auto curDiagP = curPolicy["Diag P"].get<std::vector<float>>();
 
     // Getting current experience probability and calculating importance weight
     float probability = _experienceReplay[expId].metadata["Mini Batch"]["Probability"];
@@ -203,7 +193,7 @@ void NAF::trainPolicy()
     }
 
     // Compute derivative of kullback-leibler divergence wrt current distribution params
-    std::vector<float> klGrad; //calculateKLDivergenceGradient(expMeans, expSigmas, curMeans, curSigmas);
+    std::vector<float> klGrad = calculateKLDivergenceGradient(expPolicy, curPolicy);
 
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
     {

--- a/source/modules/solver/agent/continuous/NAF/NAF._cpp
+++ b/source/modules/solver/agent/continuous/NAF/NAF._cpp
@@ -104,6 +104,11 @@ float NAF::stateValueFunction(const std::vector<std::vector<float>> &state)
   return v;
 }
 
+void NAF::updateExperienceMetadata(size_t expId)
+{
+ KORALI_LOG_ERROR("To-do.\n");
+}
+
 void NAF::trainPolicy()
 {
   /***********************************************************************************
@@ -130,8 +135,8 @@ void NAF::trainPolicy()
     // Access experiences
     auto expStateSequence = getStateTimeSequence(expId);
     auto expAction = _experienceReplay[expId].action;
-    auto expMeans = _experienceReplay[expId].policy["Action Means"].get<std::vector<float>>();
-    auto expSigmas = _experienceReplay[expId].policy["Action Sigmas"].get<std::vector<float>>();
+    auto expMeans = _experienceReplay[expId].metadata["Action Means"].get<std::vector<float>>();
+    auto expSigmas = _experienceReplay[expId].metadata["Action Sigmas"].get<std::vector<float>>();
 
     // Forward the neural network for this state to get current means and sigmas and Value
     auto policy = runPolicy(expStateSequence);
@@ -142,11 +147,11 @@ void NAF::trainPolicy()
 
     // Compute importance weight
     float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
-    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
 
     // Important: store computed information for use in retrace.
-    _experienceReplay[expId].policy["State Value"] = V;
-    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+    _experienceReplay[expId].metadata["State Value"] = V;
+    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
 
     // Getting current experience probability and calculating importance weight
     float probability = _experienceReplay[expId].metadata["Mini Batch"]["Probability"];

--- a/source/modules/solver/agent/continuous/NAF/NAF._cpp
+++ b/source/modules/solver/agent/continuous/NAF/NAF._cpp
@@ -133,10 +133,9 @@ void NAF::trainPolicy()
     auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
 
     // Gathering metadata
-    float V = _experienceReplay[expId].metadata["State Value"];
+    float V = _experienceReplay[expId].stateValue;
     auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
-    float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
-    float retV = _experienceReplay[expId].metadata["Retrace Value"];
+    float importanceWeight = _experienceReplay[expId].importanceWeight;
 
     // Gathering current policy information
     auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
@@ -199,6 +198,7 @@ void NAF::trainPolicy()
     {
       // Step towards old policy (gradient pointing to larger difference between old and current policy)
       policyGradient[1 + i] -= weight * (1.0f - _experienceReplayOffPolicyREFERBeta) * klGrad[i];
+
       // inlcude gradient of sigma wrt. diagP
       policyGradient[1 + i + _problem->_actionVectorSize] -= weight * (1.0f - _experienceReplayOffPolicyREFERBeta) * klGrad[i + _problem->_actionVectorSize] * (-0.5 * std::sqrt(_covarianceScaling) * std::pow(curDiagP[i], -1.5));
     }
@@ -241,38 +241,53 @@ void NAF::trainPolicy()
 
 knlohmann::json NAF::runPolicy(const std::vector<std::vector<float>> &state)
 {
-  auto qNNoutput = _qLearner->getEvaluation({state})[0];
-  float stateValue = qNNoutput[0];
+  // Storage for policy
+  knlohmann::json policy;
+
+  // Evaluating critic NN
+  auto eval = _qLearner->getEvaluation({state})[0];
+  float stateValue = eval[0];
 
   // Transforming NN output to receive mu and diagonal of P
-  std::vector<float> actionMeans(_problem->_actionVectorSize);
-  std::vector<float> actionSigmas(_problem->_actionVectorSize);
   std::vector<float> diagP(_problem->_actionVectorSize);
 
-  for (size_t i = 0; i < _problem->_actionVectorSize; ++i)
+  if (_policyDistribution == "Normal")
   {
-    actionMeans[i] = qNNoutput[1 + i];
-    diagP[i] = qNNoutput[1 + _problem->_actionVectorSize + i] / (_actionScalings[i] * _actionScalings[i]);
-    actionSigmas[i] = std::sqrt(_covarianceScaling) / std::sqrt(diagP[i]);
+    std::vector<float> actionMeans(_problem->_actionVectorSize);
+    std::vector<float> actionSigmas(_problem->_actionVectorSize);
+
+    for (size_t i = 0; i < _problem->_actionVectorSize; ++i)
+    {
+      actionMeans[i] = eval[1 + i];
+      diagP[i] = eval[1 + _problem->_actionVectorSize + i] / (_actionScalings[i] * _actionScalings[i]);
+      actionSigmas[i] = std::sqrt(_covarianceScaling) / std::sqrt(diagP[i]);
+    }
+
+    policy["Action Means"] = actionMeans;
+    policy["Action Sigmas"] = actionSigmas;
   }
 
   if (_policyDistribution == "Beta")
   {
+    std::vector<float> actionAlpha(_problem->_actionVectorSize);
+    std::vector<float> actionBeta(_problem->_actionVectorSize);
+
     // Transform to variance coefficient
     for (size_t i = 0; i < _problem->_actionVectorSize; ++i)
     {
-      float mux = (actionMeans[i] - _actionLowerBounds[i]) / _actionScalings[i];
-      float sigx = actionSigmas[i] / _actionScalings[i];
-      actionSigmas[i] = mux * (1.0 - mux) / sigx;
-      if (actionSigmas[i] > 1.0) actionSigmas[i] = 1.0;
+      float mux = (actionAlpha[i] - _actionLowerBounds[i]) / _actionScalings[i];
+      float sigx = actionBeta[i] / _actionScalings[i];
+      actionBeta[i] = mux * (1.0 - mux) / sigx;
+      if (actionBeta[i] > 1.0) actionBeta[i] = 1.0;
     }
+
+    policy["Action Alpha"] = actionAlpha;
+    policy["Action Beta"] = actionBeta;
   }
 
-  knlohmann::json policy;
   policy["State Value"] = stateValue;
-  policy["Action Means"] = actionMeans;
-  policy["Action Sigmas"] = actionSigmas;
   policy["Diag P"] = diagP;
+
   return policy;
 }
 

--- a/source/modules/solver/agent/continuous/NAF/NAF._cpp
+++ b/source/modules/solver/agent/continuous/NAF/NAF._cpp
@@ -135,7 +135,6 @@ void NAF::trainPolicy()
     // Gathering metadata
     float V = _experienceReplay[expId].stateValue;
     auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
-    float importanceWeight = _experienceReplay[expId].importanceWeight;
 
     // Gathering current policy information
     auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
@@ -177,11 +176,8 @@ void NAF::trainPolicy()
     // Calculating Gradients of Loss Li wrt. V(s)
     policyGradient[0] = weight * diff;
 
-    // Checking whether the experience is on policy (i.e., it is within the [1/cutoff, cutoff] region)
-    bool isOnPolicy = (importanceWeight > (1.0f / _experienceReplayOffPolicyCurrentCutoff)) && (importanceWeight < _experienceReplayOffPolicyCurrentCutoff);
-
     // Compute mu(s) & and P(s) gradient only if inside trust region (or REFER disabled)
-    if (isOnPolicy)
+    if (_experienceReplay[expId].isOnPolicy)
     {
       for (size_t i = 0; i < _problem->_actionVectorSize; i++)
       {
@@ -212,11 +208,11 @@ void NAF::trainPolicy()
     for (size_t j = 0; j < _problem->_actionVectorSize; j++) _statisticsAverageActionSigmas[j] += curSigmas[j];
   }
 
-  // Running one generation of the optimization method with the given mini-batch
-  _qLearner->runGeneration();
-
   // Updating learning rate for critic/policy learner guided by REFER
   _criticLearner->_learningRate = _currentLearningRate;
+
+  // Running one generation of the optimization method with the given mini-batch
+  _qLearner->runGeneration();
 
   // Keeping statistics
   _statisticsAverageQStar = cumulativeQStar / (float)_miniBatchSize;

--- a/source/modules/solver/agent/continuous/NAF/NAF._cpp
+++ b/source/modules/solver/agent/continuous/NAF/NAF._cpp
@@ -144,6 +144,10 @@ void NAF::trainPolicy()
     float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
     _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
 
+    // Important: store computed information for use in retrace.
+    _experienceReplay[expId].policy["State Value"] = V;
+    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+
     // Getting current experience probability and calculating importance weight
     float probability = _experienceReplay[expId].metadata["Mini Batch"]["Probability"];
     float weight = std::pow((float)_experienceReplay.size() * probability, -_importanceWeightAnnealingRate);

--- a/source/modules/solver/agent/continuous/NAF/NAF._cpp
+++ b/source/modules/solver/agent/continuous/NAF/NAF._cpp
@@ -146,7 +146,7 @@ void NAF::trainPolicy()
     auto curDiagP = policy["Diag P"].get<std::vector<float>>();
 
     // Compute importance weight
-    float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
+    float importanceWeight = 0.0f;//calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
     _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
 
     // Important: store computed information for use in retrace.
@@ -203,7 +203,7 @@ void NAF::trainPolicy()
     }
 
     // Compute derivative of kullback-leibler divergence wrt current distribution params
-    auto klGrad = calculateKLDivergenceGradient(expMeans, expSigmas, curMeans, curSigmas);
+    std::vector<float> klGrad; //calculateKLDivergenceGradient(expMeans, expSigmas, curMeans, curSigmas);
 
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
     {

--- a/source/modules/solver/agent/continuous/NAF/NAF._hpp
+++ b/source/modules/solver/agent/continuous/NAF/NAF._hpp
@@ -55,6 +55,7 @@ class NAF : public Continuous
   */
   float quadraticAdvantageFunction(const std::vector<float> &action, const std::vector<float> &mean, const std::vector<float> &diagP);
 
+  void updateExperienceMetadata(size_t expId) override;
   float stateValueFunction(const std::vector<std::vector<float>> &state) override;
   knlohmann::json getAgentPolicy() override;
   void setAgentPolicy(const knlohmann::json &hyperparameters) override;

--- a/source/modules/solver/agent/continuous/NAF/NAF._hpp
+++ b/source/modules/solver/agent/continuous/NAF/NAF._hpp
@@ -55,7 +55,6 @@ class NAF : public Continuous
   */
   float quadraticAdvantageFunction(const std::vector<float> &action, const std::vector<float> &mean, const std::vector<float> &diagP);
 
-  void updateExperienceMetadata(size_t expId) override;
   float stateValueFunction(const std::vector<std::vector<float>> &state) override;
   knlohmann::json getAgentPolicy() override;
   void setAgentPolicy(const knlohmann::json &hyperparameters) override;

--- a/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
+++ b/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
@@ -138,6 +138,9 @@ void VRACER::trainPolicy()
 
     // Compute importance weight
     float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
+
+    // Important: store computed information for use in retrace.
+    _experienceReplay[expId].policy["State Value"] = V;
     _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
 
     /******************************************************

--- a/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
+++ b/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
@@ -95,10 +95,6 @@ void VRACER::initializeAgent()
   _statisticsAverageActionSigmas.resize(_problem->_actionVectorSize);
 }
 
-void VRACER::updateExperienceMetadata(size_t expId)
-{
-}
-
 void VRACER::trainPolicy()
 {
   // Resetting statistics
@@ -247,14 +243,17 @@ void VRACER::trainPolicy()
 float VRACER::stateValueFunction(const std::vector<std::vector<float>> &state)
 {
   // Calculating V(s_i)
-  float v = _criticPolicyLearner->getEvaluation({state})[0][0];
-  return v;
+  float V = _criticPolicyLearner->getEvaluation({state})[0][0];
+  return V;
 }
 
 knlohmann::json VRACER::runPolicy(const std::vector<std::vector<float>> &state)
 {
   // Forward the neural network for this state
   auto evaluation = _criticPolicyLearner->getEvaluation({state})[0];
+
+  // Getting state value
+  float V = evaluation[0];
 
   std::vector<float> actionMeans(_problem->_actionVectorSize);
   std::vector<float> actionSigmas(_problem->_actionVectorSize);
@@ -265,6 +264,7 @@ knlohmann::json VRACER::runPolicy(const std::vector<std::vector<float>> &state)
   }
 
   knlohmann::json policy;
+  policy["State Value"] = V;
   policy["Action Means"] = actionMeans;
   policy["Action Sigmas"] = actionSigmas;
   return policy;

--- a/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
+++ b/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
@@ -132,7 +132,6 @@ void VRACER::trainPolicy()
     // Gathering metadata
     float V = _experienceReplay[expId].stateValue;
     auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
-    float importanceWeight = _experienceReplay[expId].importanceWeight;
     float expVtbc = _experienceReplay[expId].retraceValue;
 
     /******************************************************
@@ -152,11 +151,8 @@ void VRACER::trainPolicy()
     cumulativeTdError -= gradientLoss[0];
     cumulativeTdErrorSquared += gradientLoss[0] * gradientLoss[0];
 
-    // Checking whether the experience is on policy (i.e., it is within the [1/cutoff, cutoff] region)
-    bool isOnPolicy = (importanceWeight > (1.0f / _experienceReplayOffPolicyCurrentCutoff)) && (importanceWeight < _experienceReplayOffPolicyCurrentCutoff);
-
     // Compute policy gradient only if inside trust region (or offPolicy disabled)
-    if (isOnPolicy)
+    if (_experienceReplay[expId].isOnPolicy)
     {
       // Qret for terminal state is just reward
       float Qret = _experienceReplay[expId].reward;

--- a/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
+++ b/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
@@ -130,10 +130,10 @@ void VRACER::trainPolicy()
     auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
 
     // Gathering metadata
-    float V = _experienceReplay[expId].metadata["State Value"];
+    float V = _experienceReplay[expId].stateValue;
     auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
-    float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
-    float expVtbc = _experienceReplay[expId].metadata["Retrace Value"];
+    float importanceWeight = _experienceReplay[expId].importanceWeight;
+    float expVtbc = _experienceReplay[expId].retraceValue;
 
     /******************************************************
     * Gradient calculation
@@ -167,7 +167,7 @@ void VRACER::trainPolicy()
       // In this case add Vtbc
       if (isNormal == true)
       {
-        float nextExpVtbc =_experienceReplay[expId+1].metadata["Retrace Value"];
+        float nextExpVtbc = _experienceReplay[expId + 1].retraceValue;
         Qret += _discountFactor * nextExpVtbc;
       }
 
@@ -177,7 +177,7 @@ void VRACER::trainPolicy()
       // For truncated state add value
       if (isTrucated == true)
       {
-        float nextExpVtbc = _experienceReplay[expId].metadata["Truncated State Value"];
+        float nextExpVtbc = _experienceReplay[expId].truncatedStateValue;
         Qret += _discountFactor * nextExpVtbc;
       }
 
@@ -249,24 +249,47 @@ float VRACER::stateValueFunction(const std::vector<std::vector<float>> &state)
 
 knlohmann::json VRACER::runPolicy(const std::vector<std::vector<float>> &state)
 {
+  // Storage for policy
+  knlohmann::json policy;
+
   // Forward the neural network for this state
   auto evaluation = _criticPolicyLearner->getEvaluation({state})[0];
 
   // Getting state value
   float V = evaluation[0];
+  policy["State Value"] = V;
 
-  std::vector<float> actionMeans(_problem->_actionVectorSize);
-  std::vector<float> actionSigmas(_problem->_actionVectorSize);
-  for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+  // Getting distribution parameters
+  if (_policyDistribution == "Normal")
   {
-    actionMeans[i] = evaluation[i + 1];
-    actionSigmas[i] = evaluation[_problem->_actionVectorSize + i + 1];
+    std::vector<float> actionMeans(_problem->_actionVectorSize);
+    std::vector<float> actionSigmas(_problem->_actionVectorSize);
+
+    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+    {
+      actionMeans[i] = evaluation[i + 1];
+      actionSigmas[i] = evaluation[_problem->_actionVectorSize + i + 1];
+    }
+
+    policy["Action Means"] = actionMeans;
+    policy["Action Sigmas"] = actionSigmas;
   }
 
-  knlohmann::json policy;
-  policy["State Value"] = V;
-  policy["Action Means"] = actionMeans;
-  policy["Action Sigmas"] = actionSigmas;
+  if (_policyDistribution == "Beta")
+  {
+    std::vector<float> actionAlpha(_problem->_actionVectorSize);
+    std::vector<float> actionBeta(_problem->_actionVectorSize);
+
+    for (size_t i = 0; i < _problem->_actionVectorSize; i++)
+    {
+      actionAlpha[i] = evaluation[i + 1];
+      actionBeta[i] = evaluation[_problem->_actionVectorSize + i + 1];
+    }
+
+    policy["Action Alpha"] = actionAlpha;
+    policy["Action Beta"] = actionBeta;
+  }
+
   return policy;
 }
 

--- a/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
+++ b/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
@@ -95,6 +95,33 @@ void VRACER::initializeAgent()
   _statisticsAverageActionSigmas.resize(_problem->_actionVectorSize);
 }
 
+void VRACER::updateExperienceMetadata(size_t expId)
+{
+ // Get state, action, mean, Sigma for this experience
+ auto expStateSequence = getStateTimeSequence(expId);
+ auto expAction = _experienceReplay[expId].action;
+ auto expMeans = _experienceReplay[expId].metadata["Action Means"].get<std::vector<float>>();
+ auto expSigmas = _experienceReplay[expId].metadata["Action Sigmas"].get<std::vector<float>>();
+
+ // Forward the neural network for this state to get current means and sigmas and Value
+ auto policy = runPolicy(expStateSequence);
+ float V = policy["State Value"].get<float>();
+ auto curMeans = policy["Action Means"].get<std::vector<float>>();
+ auto curSigmas = policy["Action Sigmas"].get<std::vector<float>>();
+
+ // Compute importance weight
+ float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
+
+ // Store computed information for use in retrace.
+ #pragma omp critical
+ {
+  _experienceReplay[expId].metadata["State Value"] = V;
+  _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
+  _experienceReplay[expId].metadata["Current Means"] = curMeans;
+  _experienceReplay[expId].metadata["Current Sigmas"] = curSigmas;
+ }
+}
+
 void VRACER::trainPolicy()
 {
   // Resetting statistics
@@ -127,21 +154,15 @@ void VRACER::trainPolicy()
     // Get state, action, mean, Sigma for this experience
     auto expStateSequence = getStateTimeSequence(expId);
     auto expAction = _experienceReplay[expId].action;
-    auto expMeans = _experienceReplay[expId].policy["Action Means"].get<std::vector<float>>();
-    auto expSigmas = _experienceReplay[expId].policy["Action Sigmas"].get<std::vector<float>>();
+    auto expMeans = _experienceReplay[expId].metadata["Action Means"].get<std::vector<float>>();
+    auto expSigmas = _experienceReplay[expId].metadata["Action Sigmas"].get<std::vector<float>>();
 
-    // Forward the neural network for this state to get current means and sigmas and Value
-    auto policy = runPolicy(expStateSequence);
-    float V = policy["State Value"].get<float>();
-    auto curMeans = policy["Action Means"].get<std::vector<float>>();
-    auto curSigmas = policy["Action Sigmas"].get<std::vector<float>>();
-
-    // Compute importance weight
-    float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
-
-    // Important: store computed information for use in retrace.
-    _experienceReplay[expId].policy["State Value"] = V;
-    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+    // Gathering metadata
+    float V = _experienceReplay[expId].metadata["State Value"];
+    auto curMeans = _experienceReplay[expId].metadata["Current Means"].get<std::vector<float>>();
+    auto curSigmas = _experienceReplay[expId].metadata["Current Sigmas"].get<std::vector<float>>();
+    float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
+    float expVtbc = _experienceReplay[expId].metadata["Retrace Value"];
 
     /******************************************************
     * Gradient calculation
@@ -149,9 +170,6 @@ void VRACER::trainPolicy()
 
     // Storage for the update gradient
     std::vector<float> gradientLoss(1 + 2 * _problem->_actionVectorSize);
-
-    // Get Vtbc before update
-    float expVtbc = retraceFunction(expId);
 
     // Keeping critic statistics
     cumulativeQStar += expVtbc;
@@ -279,9 +297,9 @@ knlohmann::json VRACER::runPolicy(const std::vector<std::vector<float>> &state)
   }
 
   knlohmann::json policy;
+  policy["State Value"] = stateValue;
   policy["Action Means"] = actionMeans;
   policy["Action Sigmas"] = actionSigmas;
-  policy["State Value"] = stateValue;
   return policy;
 }
 

--- a/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
+++ b/source/modules/solver/agent/continuous/VRACER/VRACER._cpp
@@ -97,29 +97,6 @@ void VRACER::initializeAgent()
 
 void VRACER::updateExperienceMetadata(size_t expId)
 {
- // Get state, action, mean, Sigma for this experience
- auto expStateSequence = getStateTimeSequence(expId);
- auto expAction = _experienceReplay[expId].action;
- auto expMeans = _experienceReplay[expId].metadata["Action Means"].get<std::vector<float>>();
- auto expSigmas = _experienceReplay[expId].metadata["Action Sigmas"].get<std::vector<float>>();
-
- // Forward the neural network for this state to get current means and sigmas and Value
- auto policy = runPolicy(expStateSequence);
- float V = policy["State Value"].get<float>();
- auto curMeans = policy["Action Means"].get<std::vector<float>>();
- auto curSigmas = policy["Action Sigmas"].get<std::vector<float>>();
-
- // Compute importance weight
- float importanceWeight = calculateImportanceWeight(expAction, curMeans, curSigmas, expMeans, expSigmas);
-
- // Store computed information for use in retrace.
- #pragma omp critical
- {
-  _experienceReplay[expId].metadata["State Value"] = V;
-  _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
-  _experienceReplay[expId].metadata["Current Means"] = curMeans;
-  _experienceReplay[expId].metadata["Current Sigmas"] = curSigmas;
- }
 }
 
 void VRACER::trainPolicy()
@@ -151,16 +128,14 @@ void VRACER::trainPolicy()
     // Getting index of current experiment
     size_t expId = miniBatchIndexes[b];
 
-    // Get state, action, mean, Sigma for this experience
+    // Get state, action and policy for this experience
     auto expStateSequence = getStateTimeSequence(expId);
     auto expAction = _experienceReplay[expId].action;
-    auto expMeans = _experienceReplay[expId].metadata["Action Means"].get<std::vector<float>>();
-    auto expSigmas = _experienceReplay[expId].metadata["Action Sigmas"].get<std::vector<float>>();
+    auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
 
     // Gathering metadata
     float V = _experienceReplay[expId].metadata["State Value"];
-    auto curMeans = _experienceReplay[expId].metadata["Current Means"].get<std::vector<float>>();
-    auto curSigmas = _experienceReplay[expId].metadata["Current Sigmas"].get<std::vector<float>>();
+    auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
     float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
     float expVtbc = _experienceReplay[expId].metadata["Retrace Value"];
 
@@ -196,7 +171,7 @@ void VRACER::trainPolicy()
       // In this case add Vtbc
       if (isNormal == true)
       {
-        float nextExpVtbc = retraceFunction(expId + 1);
+        float nextExpVtbc =_experienceReplay[expId+1].metadata["Retrace Value"];
         Qret += _discountFactor * nextExpVtbc;
       }
 
@@ -206,13 +181,7 @@ void VRACER::trainPolicy()
       // For truncated state add value
       if (isTrucated == true)
       {
-        // get truncated state
-        auto truncatedState = getTruncatedStateTimeSequence(expId);
-
-        // for truncated state, Vtbc == V - forward network
-        float nextExpVtbc = stateValueFunction(truncatedState);
-
-        // add value to Qret
+        float nextExpVtbc = _experienceReplay[expId].metadata["Truncated State Value"];
         Qret += _discountFactor * nextExpVtbc;
       }
 
@@ -225,7 +194,7 @@ void VRACER::trainPolicy()
       policyErrorCounter++;
 
       // Compute Policy Gradient wrt Params
-      auto polGrad = calculateImportanceWeightGradient(expAction, curMeans, curSigmas, expMeans, expSigmas);
+      auto polGrad = calculateImportanceWeightGradient(expAction, curPolicy, expPolicy);
 
       // Set Gradient of Loss wrt Params
       for (size_t i = 0; i < 2 * _problem->_actionVectorSize; i++)
@@ -233,14 +202,14 @@ void VRACER::trainPolicy()
     }
 
     // Compute derivative of kullback-leibler divergence wrt current distribution params
-    auto klGrad = calculateKLDivergenceGradient(expMeans, expSigmas, curMeans, curSigmas);
+    auto klGrad = calculateKLDivergenceGradient(expPolicy, curPolicy);
 
     // Step towards old policy (gradient pointing to larger difference between old and current policy)
     for (size_t i = 0; i < 2 * _problem->_actionVectorSize; i++)
       gradientLoss[1 + i] -= (1.0f - _experienceReplayOffPolicyREFERBeta) * klGrad[i];
 
     // Compute statistics
-    for (size_t i = 0; i < _problem->_actionVectorSize; i++) _statisticsAverageActionSigmas[i] += curSigmas[i];
+    for (size_t i = 0; i < _problem->_actionVectorSize; i++) _statisticsAverageActionSigmas[i] += curPolicy["Action Sigmas"][i].get<float>();
 
     // Set status as learning problem input
     _criticPolicyProblem->_inputData[b] = expStateSequence;
@@ -286,7 +255,6 @@ knlohmann::json VRACER::runPolicy(const std::vector<std::vector<float>> &state)
 {
   // Forward the neural network for this state
   auto evaluation = _criticPolicyLearner->getEvaluation({state})[0];
-  auto stateValue = evaluation[0];
 
   std::vector<float> actionMeans(_problem->_actionVectorSize);
   std::vector<float> actionSigmas(_problem->_actionVectorSize);
@@ -297,7 +265,6 @@ knlohmann::json VRACER::runPolicy(const std::vector<std::vector<float>> &state)
   }
 
   knlohmann::json policy;
-  policy["State Value"] = stateValue;
   policy["Action Means"] = actionMeans;
   policy["Action Sigmas"] = actionSigmas;
   return policy;

--- a/source/modules/solver/agent/continuous/VRACER/VRACER._hpp
+++ b/source/modules/solver/agent/continuous/VRACER/VRACER._hpp
@@ -37,7 +37,6 @@ class VRACER : public Continuous
    */
   void updateVtbc(size_t expId);
 
-  void updateExperienceMetadata(size_t expId) override;
   float stateValueFunction(const std::vector<std::vector<float>> &stateSequence) override;
   knlohmann::json getAgentPolicy() override;
   void setAgentPolicy(const knlohmann::json &hyperparameters) override;

--- a/source/modules/solver/agent/continuous/VRACER/VRACER._hpp
+++ b/source/modules/solver/agent/continuous/VRACER/VRACER._hpp
@@ -37,6 +37,7 @@ class VRACER : public Continuous
    */
   void updateVtbc(size_t expId);
 
+  void updateExperienceMetadata(size_t expId) override;
   float stateValueFunction(const std::vector<std::vector<float>> &stateSequence) override;
   knlohmann::json getAgentPolicy() override;
   void setAgentPolicy(const knlohmann::json &hyperparameters) override;

--- a/source/modules/solver/agent/continuous/continuous._cpp
+++ b/source/modules/solver/agent/continuous/continuous._cpp
@@ -17,7 +17,7 @@ void Continuous::initializeAgent()
     KORALI_LOG_ERROR("Policy Distribution must be either 'Normal' or 'Beta' (is '%s').", _policyDistribution.c_str());
 
   /*********************************************************************
-  * Initializing Action Noise Sigmas
+  * Initializing Action Space Information
   *********************************************************************/
 
   // Allocating space for the inverse variance calculation
@@ -53,68 +53,78 @@ void Continuous::getAction(korali::Sample &sample)
 
   // Forward state sequence to get the Gaussian means and sigmas from policy
   auto policy = runPolicy(_stateTimeSequence.getVector());
-  auto curMeans = policy["Action Means"].get<std::vector<float>>();
-  auto curSigmas = policy["Action Sigmas"].get<std::vector<float>>();
 
   /*****************************************************************************
   * During Training we select action according to policy's probability 
   * distribution
   ****************************************************************************/
 
-  if (sample["Mode"] == "Training") action = generateTrainingAction(curMeans, curSigmas);
+  if (sample["Mode"] == "Training") action = generateTrainingAction(policy);
 
   /*****************************************************************************
   * During testing, we select the means (point of highest density) for all
   * elements of the action vector
   ****************************************************************************/
 
-  if (sample["Mode"] == "Testing") action = generateTestingAction(curMeans, curSigmas);
+  if (sample["Mode"] == "Testing") action = generateTestingAction(policy);
 
   /*****************************************************************************
   * Storing the action and it's policy
   ****************************************************************************/
 
-  sample["Metadata"]["Experience Policy"]["Action Means"] = curMeans;
-  sample["Metadata"]["Experience Policy"]["Action Sigmas"] = curSigmas;
+  sample["Metadata"]["Experience Policy"] = policy;
   sample["Action"] = action;
 }
 
-std::vector<float> Continuous::generateTrainingAction(const std::vector<float> &paramsOne, const std::vector<float> &paramsTwo)
+std::vector<float> Continuous::generateTrainingAction(knlohmann::json &curPolicy)
 {
   std::vector<float> action(_problem->_actionVectorSize);
   if (_policyDistribution == "Normal")
   {
-    // ParamsOne are the Means, ParamsTwo are the Sigmas
+    // Getting parameters from the new and old policies
+    auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+    auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
+
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-      action[i] = paramsOne[i] + paramsTwo[i] * _normalGenerator->getRandomNumber();
+      action[i] = curMeans[i] + curSigmas[i] * _normalGenerator->getRandomNumber();
   }
-  else /* _policyDistribution == "Beta" */
+
+  if (_policyDistribution == "Beta")
   {
-    // ParamsOne are the Means, ParamsTwo are the Variance Coefficients
+    auto curAlpha = curPolicy["Action Alpha"].get<std::vector<float>>();
+    auto curBeta = curPolicy["Action Beta"].get<std::vector<float>>();
+
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-      action[i] = ranBetaAlt(_normalGenerator->_range, paramsOne[i], paramsTwo[i], _actionLowerBounds[i], _actionUpperBounds[i]);
+      action[i] = ranBetaAlt(_normalGenerator->_range, curAlpha[i], curBeta[i], _actionLowerBounds[i], _actionUpperBounds[i]);
   }
 
   return action;
 }
 
-std::vector<float> Continuous::generateTestingAction(const std::vector<float> &paramsOne, const std::vector<float> &paramsTwo)
+std::vector<float> Continuous::generateTestingAction(knlohmann::json &curPolicy)
 {
   std::vector<float> action(_problem->_actionVectorSize);
   if (_policyDistribution == "Normal")
   {
+    // Getting parameters from the new and old policies
+    auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+
     // ParamsOne are the Means, ParamsTwo are the Sigmas
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
-      action[i] = paramsOne[i];
+      action[i] = curMeans[i];
   }
-  else /* _policyDistribution == "Beta" */
+
+  if (_policyDistribution == "Beta")
   {
+    auto curAlpha = curPolicy["Action Alpha"].get<std::vector<float>>();
+    auto curBeta = curPolicy["Action Beta"].get<std::vector<float>>();
+
     // ParamsOne are the Means, ParamsTwo are the Variance Coefficients
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
     {
       float alpha;
       float beta;
-      std::tie(alpha, beta) = betaParamTransformAlt(paramsOne[i], paramsTwo[i], _actionLowerBounds[i], _actionUpperBounds[i]);
+      std::tie(alpha, beta) = betaParamTransformAlt(curAlpha[i], curBeta[i], _actionLowerBounds[i], _actionUpperBounds[i]);
 
       if (alpha > 1. && beta > 1.)
         action[i] = _actionLowerBounds[i] + (_actionUpperBounds[i] - _actionLowerBounds[i]) * (alpha - 1) / (alpha + beta - 2);
@@ -135,15 +145,15 @@ float Continuous::calculateImportanceWeight(const std::vector<float> &action, kn
   float logpCurPolicy = 0.0f;
   float logpOldPolicy = 0.0f;
 
-  // Getting parameters from the new and old policies
-  auto oldMeans = oldPolicy["Action Means"].get<std::vector<float>>();
-  auto oldSigmas = oldPolicy["Action Sigmas"].get<std::vector<float>>();
-  auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
-  auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
-
   // Getting probability densities for current and past action given current policy
   if (_policyDistribution == "Normal")
   {
+    // Getting parameters from the new and old policies
+    auto oldMeans = oldPolicy["Action Means"].get<std::vector<float>>();
+    auto oldSigmas = oldPolicy["Action Sigmas"].get<std::vector<float>>();
+    auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+    auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
+
     // ParamsOne are the Means, ParamsTwo are the Sigmas
     for (size_t i = 0; i < action.size(); i++)
     {
@@ -151,13 +161,20 @@ float Continuous::calculateImportanceWeight(const std::vector<float> &action, kn
       logpCurPolicy += normalLogDensity(action[i], curMeans[i], curSigmas[i]);
     }
   }
-  else /* _policyDistribution == "Beta" */
+
+  if (_policyDistribution == "Beta")
   {
+    // Getting parameters from the new and old policies
+    auto oldAlpha = oldPolicy["Action Alpha"].get<std::vector<float>>();
+    auto oldBeta = oldPolicy["Action Beta"].get<std::vector<float>>();
+    auto curAlpha = curPolicy["Action Alpha"].get<std::vector<float>>();
+    auto curBeta = curPolicy["Action Beta"].get<std::vector<float>>();
+
     // ParamsOne are the Means, ParamsTwo are the Variance Coefficients
     for (size_t i = 0; i < action.size(); i++)
     {
-      logpOldPolicy += betaLogDensityAlt(action[i], oldMeans[i], oldSigmas[i], _actionLowerBounds[i], _actionUpperBounds[i]);
-      logpCurPolicy += betaLogDensityAlt(action[i], curMeans[i], curSigmas[i], _actionLowerBounds[i], _actionUpperBounds[i]);
+      logpOldPolicy += betaLogDensityAlt(action[i], oldAlpha[i], oldBeta[i], _actionLowerBounds[i], _actionUpperBounds[i]);
+      logpCurPolicy += betaLogDensityAlt(action[i], curAlpha[i], curBeta[i], _actionLowerBounds[i], _actionUpperBounds[i]);
     }
   }
 
@@ -177,14 +194,14 @@ std::vector<float> Continuous::calculateImportanceWeightGradient(const std::vect
 {
   std::vector<float> grad(2 * _problem->_actionVectorSize, 0.0);
 
-  // Getting parameters from the new and old policies
-  auto oldMeans = oldPolicy["Action Means"].get<std::vector<float>>();
-  auto oldSigmas = oldPolicy["Action Sigmas"].get<std::vector<float>>();
-  auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
-  auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
-
   if (_policyDistribution == "Normal")
   {
+    // Getting parameters from the new and old policies
+    auto oldMeans = oldPolicy["Action Means"].get<std::vector<float>>();
+    auto oldSigmas = oldPolicy["Action Sigmas"].get<std::vector<float>>();
+    auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+    auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
+
     float logImportanceWeight = 0.0;
 
     // ParamsOne are the Means, ParamsTwo are the Sigmas
@@ -217,21 +234,28 @@ std::vector<float> Continuous::calculateImportanceWeightGradient(const std::vect
     for (size_t i = 0; i < 2 * _problem->_actionVectorSize; i++)
       grad[i] *= importanceWeight;
   }
-  else /* _policyDistribution == "Beta" */
+
+  if (_policyDistribution == "Beta")
   {
+    // Getting parameters from the new and old policies
+    auto oldAlpha = oldPolicy["Action Alpha"].get<std::vector<float>>();
+    auto oldBeta = oldPolicy["Action Beta"].get<std::vector<float>>();
+    auto curAlpha = curPolicy["Action Alpha"].get<std::vector<float>>();
+    auto curBeta = curPolicy["Action Beta"].get<std::vector<float>>();
+
     // ParamsOne are the Means, ParamsTwo are the Variance Coefficients
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
     {
       // Variable preparation
-      const float muCur = curMeans[i];
-      const float varcoefCur = curSigmas[i];
+      const float muCur = curAlpha[i];
+      const float varcoefCur = curBeta[i];
 
       float alphaCur;
       float betaCur;
       std::tie(alphaCur, betaCur) = betaParamTransformAlt(muCur, varcoefCur, _actionLowerBounds[i], _actionUpperBounds[i]);
 
-      const float muOld = oldMeans[i];
-      const float varcoefOld = oldSigmas[i];
+      const float muOld = oldAlpha[i];
+      const float varcoefOld = oldBeta[i];
 
       float alphaOld;
       float betaOld;
@@ -243,7 +267,6 @@ std::vector<float> Continuous::calculateImportanceWeightGradient(const std::vect
 
       // Variable preparation
       const float Bab = gsl_sf_beta(alphaCur, betaCur);
-
       const float psiAb = gsl_sf_psi(alphaCur + betaCur);
 
       const float logscale = std::log(_actionScalings[i]);
@@ -273,15 +296,14 @@ std::vector<float> Continuous::calculateKLDivergenceGradient(knlohmann::json &ol
 {
   std::vector<float> klGrad(2.0 * _problem->_actionVectorSize, 0.0);
 
-  // Getting parameters from the new and old policies
-  auto oldMeans = oldPolicy["Action Means"].get<std::vector<float>>();
-  auto oldSigmas = oldPolicy["Action Sigmas"].get<std::vector<float>>();
-  auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
-  auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
-
   if (_policyDistribution == "Normal")
   {
-    // ParamsOne are the Means, ParamsTwo are the Sigmas
+    // Getting parameters from the new and old policies
+    auto oldMeans = oldPolicy["Action Means"].get<std::vector<float>>();
+    auto oldSigmas = oldPolicy["Action Sigmas"].get<std::vector<float>>();
+    auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+    auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
+
     for (size_t i = 0; i < _problem->_actionVectorSize; ++i)
     {
       float curInvVar = 1. / (curSigmas[i] * curSigmas[i]);
@@ -303,21 +325,28 @@ std::vector<float> Continuous::calculateKLDivergenceGradient(knlohmann::json &ol
       klGrad[_problem->_actionVectorSize + i] = gradTr + gradQuad + gradDet;
     }
   }
-  else /* _policyDistribution == "Beta" */
+
+  if (_policyDistribution == "Beta")
   {
     // ParamsOne are the Means, ParamsTwo are the Variance Coefficients
     for (size_t i = 0; i < _problem->_actionVectorSize; ++i)
     {
+      // Getting parameters from the new and old policies
+      auto oldAlpha = oldPolicy["Action Alpha"].get<std::vector<float>>();
+      auto oldBeta = oldPolicy["Action Beta"].get<std::vector<float>>();
+      auto curAlpha = curPolicy["Action Alpha"].get<std::vector<float>>();
+      auto curBeta = curPolicy["Action Beta"].get<std::vector<float>>();
+
       // Variable preparation
-      const float muCur = curMeans[i];
-      const float varcoefCur = curSigmas[i];
+      const float muCur = curAlpha[i];
+      const float varcoefCur = curBeta[i];
 
       float alphaCur;
       float betaCur;
       std::tie(alphaCur, betaCur) = betaParamTransformAlt(muCur, varcoefCur, _actionLowerBounds[i], _actionUpperBounds[i]);
 
-      const float muOld = oldMeans[i];
-      const float varcoefOld = oldSigmas[i];
+      const float muOld = oldAlpha[i];
+      const float varcoefOld = oldBeta[i];
 
       float alphaOld;
       float betaOld;

--- a/source/modules/solver/agent/continuous/continuous._cpp
+++ b/source/modules/solver/agent/continuous/continuous._cpp
@@ -74,10 +74,8 @@ void Continuous::getAction(korali::Sample &sample)
   * Storing the action and it's policy
   ****************************************************************************/
 
-  sample["Policy"] = policy;
-  sample["Policy"]["Importance Weight"] = 1.0f;
-  sample["Policy"]["KL Divergence Gradient"] = std::vector<float>(_problem->_actionVectorSize, 0.0f);
-
+  sample["Metadata"]["Action Means"] = curMeans;
+  sample["Metadata"]["Action Sigmas"] = curSigmas;
   sample["Action"] = action;
 }
 
@@ -327,31 +325,6 @@ std::vector<float> Continuous::calculateKLDivergenceGradient(const std::vector<f
   }
 
   return klGrad;
-}
-
-float Continuous::getExperienceImportanceWeight(size_t expId)
-{
-  // Getting the state sequence and action for the given experience
-  auto expStateSequence = getStateTimeSequence(expId);
-  auto expAction = _experienceReplay[expId].action;
-
-  // Get means and sigmas for the given experience
-  auto expMeans = _experienceReplay[expId].policy["Action Means"].get<std::vector<float>>();
-  auto expSigmas = _experienceReplay[expId].policy["Action Sigmas"].get<std::vector<float>>();
-
-  // Getting current policy and calculating its means and sigmas for the given experience
-  auto policy = runPolicy(expStateSequence);
-  auto curMeans = policy["Action Means"].get<std::vector<float>>();
-  auto curSigmas = policy["Action Sigmas"].get<std::vector<float>>();
-
-  // Now calculating importance weight
-  auto expImportanceWeight = calculateImportanceWeight(expAction, expMeans, expSigmas, curMeans, curSigmas);
-
-  // Updating the impiortance weight value in the experience replay memory
-  _experienceReplay[expId].policy["Importance Weight"] = expImportanceWeight;
-
-  // Returning experience's importance weight
-  return expImportanceWeight;
 }
 
 } // namespace agent

--- a/source/modules/solver/agent/continuous/continuous._cpp
+++ b/source/modules/solver/agent/continuous/continuous._cpp
@@ -74,8 +74,8 @@ void Continuous::getAction(korali::Sample &sample)
   * Storing the action and it's policy
   ****************************************************************************/
 
-  sample["Metadata"]["Action Means"] = curMeans;
-  sample["Metadata"]["Action Sigmas"] = curSigmas;
+  sample["Metadata"]["Experience Policy"]["Action Means"] = curMeans;
+  sample["Metadata"]["Experience Policy"]["Action Sigmas"] = curSigmas;
   sample["Action"] = action;
 }
 
@@ -130,10 +130,16 @@ std::vector<float> Continuous::generateTestingAction(const std::vector<float> &p
   return action;
 }
 
-float Continuous::calculateImportanceWeight(const std::vector<float> &action, const std::vector<float> &curParamsOne, const std::vector<float> &curParamsTwo, const std::vector<float> &oldParamsOne, const std::vector<float> &oldParamsTwo)
+float Continuous::calculateImportanceWeight(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy)
 {
   float logpCurPolicy = 0.0f;
   float logpOldPolicy = 0.0f;
+
+  // Getting parameters from the new and old policies
+  auto oldMeans = oldPolicy["Action Means"].get<std::vector<float>>();
+  auto oldSigmas = oldPolicy["Action Sigmas"].get<std::vector<float>>();
+  auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+  auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
 
   // Getting probability densities for current and past action given current policy
   if (_policyDistribution == "Normal")
@@ -141,8 +147,8 @@ float Continuous::calculateImportanceWeight(const std::vector<float> &action, co
     // ParamsOne are the Means, ParamsTwo are the Sigmas
     for (size_t i = 0; i < action.size(); i++)
     {
-      logpOldPolicy += normalLogDensity(action[i], oldParamsOne[i], oldParamsTwo[i]);
-      logpCurPolicy += normalLogDensity(action[i], curParamsOne[i], curParamsTwo[i]);
+      logpOldPolicy += normalLogDensity(action[i], oldMeans[i], oldSigmas[i]);
+      logpCurPolicy += normalLogDensity(action[i], curMeans[i], curSigmas[i]);
     }
   }
   else /* _policyDistribution == "Beta" */
@@ -150,8 +156,8 @@ float Continuous::calculateImportanceWeight(const std::vector<float> &action, co
     // ParamsOne are the Means, ParamsTwo are the Variance Coefficients
     for (size_t i = 0; i < action.size(); i++)
     {
-      logpOldPolicy += betaLogDensityAlt(action[i], oldParamsOne[i], oldParamsTwo[i], _actionLowerBounds[i], _actionUpperBounds[i]);
-      logpCurPolicy += betaLogDensityAlt(action[i], curParamsOne[i], curParamsTwo[i], _actionLowerBounds[i], _actionUpperBounds[i]);
+      logpOldPolicy += betaLogDensityAlt(action[i], oldMeans[i], oldSigmas[i], _actionLowerBounds[i], _actionUpperBounds[i]);
+      logpCurPolicy += betaLogDensityAlt(action[i], curMeans[i], curSigmas[i], _actionLowerBounds[i], _actionUpperBounds[i]);
     }
   }
 
@@ -167,9 +173,15 @@ float Continuous::calculateImportanceWeight(const std::vector<float> &action, co
   return importanceWeight;
 }
 
-std::vector<float> Continuous::calculateImportanceWeightGradient(const std::vector<float> &action, const std::vector<float> &curParamsOne, const std::vector<float> &curParamsTwo, const std::vector<float> &oldParamsOne, const std::vector<float> &oldParamsTwo)
+std::vector<float> Continuous::calculateImportanceWeightGradient(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy)
 {
   std::vector<float> grad(2 * _problem->_actionVectorSize, 0.0);
+
+  // Getting parameters from the new and old policies
+  auto oldMeans = oldPolicy["Action Means"].get<std::vector<float>>();
+  auto oldSigmas = oldPolicy["Action Sigmas"].get<std::vector<float>>();
+  auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+  auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
 
   if (_policyDistribution == "Normal")
   {
@@ -179,24 +191,24 @@ std::vector<float> Continuous::calculateImportanceWeightGradient(const std::vect
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
     {
       // Deviation from expAction and current Mean
-      float curActionDiff = (action[i] - curParamsOne[i]);
+      float curActionDiff = (action[i] - curMeans[i]);
 
       // Deviation from expAction and old Mean
-      float oldActionDiff = (action[i] - oldParamsOne[i]);
+      float oldActionDiff = (action[i] - oldMeans[i]);
 
       // Inverse Variances
-      float curInvVar = 1. / (curParamsTwo[i] * curParamsTwo[i]);
-      float oldInvVar = 1. / (oldParamsTwo[i] * oldParamsTwo[i]);
+      float curInvVar = 1. / (curSigmas[i] * curSigmas[i]);
+      float oldInvVar = 1. / (oldSigmas[i] * oldSigmas[i]);
 
       // Calc Imp Weight
-      logImportanceWeight += std::log(oldParamsTwo[i] / curParamsTwo[i]);
+      logImportanceWeight += std::log(oldSigmas[i] / curSigmas[i]);
       logImportanceWeight += 0.5 * (oldActionDiff * oldActionDiff * oldInvVar - curActionDiff * curActionDiff * curInvVar);
 
       // Gradient with respect to Mean
       grad[i] = curActionDiff * curInvVar;
 
       // Gradient with respect to Sigma
-      grad[_problem->_actionVectorSize + i] = (curActionDiff * curActionDiff) * (curInvVar / curParamsTwo[i]) - 1.0f / curParamsTwo[i];
+      grad[_problem->_actionVectorSize + i] = (curActionDiff * curActionDiff) * (curInvVar / curSigmas[i]) - 1.0f / curSigmas[i];
     }
 
     float importanceWeight = std::exp(logImportanceWeight);
@@ -211,15 +223,15 @@ std::vector<float> Continuous::calculateImportanceWeightGradient(const std::vect
     for (size_t i = 0; i < _problem->_actionVectorSize; i++)
     {
       // Variable preparation
-      const float muCur = curParamsOne[i];
-      const float varcoefCur = curParamsTwo[i];
+      const float muCur = curMeans[i];
+      const float varcoefCur = curSigmas[i];
 
       float alphaCur;
       float betaCur;
       std::tie(alphaCur, betaCur) = betaParamTransformAlt(muCur, varcoefCur, _actionLowerBounds[i], _actionUpperBounds[i]);
 
-      const float muOld = oldParamsOne[i];
-      const float varcoefOld = oldParamsTwo[i];
+      const float muOld = oldMeans[i];
+      const float varcoefOld = oldSigmas[i];
 
       float alphaOld;
       float betaOld;
@@ -257,29 +269,35 @@ std::vector<float> Continuous::calculateImportanceWeightGradient(const std::vect
   return grad;
 }
 
-std::vector<float> Continuous::calculateKLDivergenceGradient(const std::vector<float> &oldParamsOne, const std::vector<float> &oldParamsTwo, const std::vector<float> &curParamsOne, const std::vector<float> &curParamsTwo)
+std::vector<float> Continuous::calculateKLDivergenceGradient(knlohmann::json &oldPolicy, knlohmann::json &curPolicy)
 {
   std::vector<float> klGrad(2.0 * _problem->_actionVectorSize, 0.0);
+
+  // Getting parameters from the new and old policies
+  auto oldMeans = oldPolicy["Action Means"].get<std::vector<float>>();
+  auto oldSigmas = oldPolicy["Action Sigmas"].get<std::vector<float>>();
+  auto curMeans = curPolicy["Action Means"].get<std::vector<float>>();
+  auto curSigmas = curPolicy["Action Sigmas"].get<std::vector<float>>();
 
   if (_policyDistribution == "Normal")
   {
     // ParamsOne are the Means, ParamsTwo are the Sigmas
     for (size_t i = 0; i < _problem->_actionVectorSize; ++i)
     {
-      float curInvVar = 1. / (curParamsTwo[i] * curParamsTwo[i]);
-      float actionDiff = (curParamsOne[i] - oldParamsOne[i]);
+      float curInvVar = 1. / (curSigmas[i] * curSigmas[i]);
+      float actionDiff = (curMeans[i] - oldMeans[i]);
 
       // KL-Gradient with respect to Mean
       klGrad[i] = actionDiff * curInvVar;
 
       // Contribution to Sigma from Trace
-      float gradTr = -(curInvVar / curParamsTwo[i]) * oldParamsTwo[i] * oldParamsTwo[i];
+      float gradTr = -(curInvVar / curSigmas[i]) * oldSigmas[i] * oldSigmas[i];
 
       // Contribution to Sigma from Quadratic term
-      float gradQuad = -(actionDiff * actionDiff) * (curInvVar / curParamsTwo[i]);
+      float gradQuad = -(actionDiff * actionDiff) * (curInvVar / curSigmas[i]);
 
       // Contribution to Sigma from Determinant
-      float gradDet = 1.0f / curParamsTwo[i];
+      float gradDet = 1.0f / curSigmas[i];
 
       // KL-Gradient with respect to Sigma
       klGrad[_problem->_actionVectorSize + i] = gradTr + gradQuad + gradDet;
@@ -291,15 +309,15 @@ std::vector<float> Continuous::calculateKLDivergenceGradient(const std::vector<f
     for (size_t i = 0; i < _problem->_actionVectorSize; ++i)
     {
       // Variable preparation
-      const float muCur = curParamsOne[i];
-      const float varcoefCur = curParamsTwo[i];
+      const float muCur = curMeans[i];
+      const float varcoefCur = curSigmas[i];
 
       float alphaCur;
       float betaCur;
       std::tie(alphaCur, betaCur) = betaParamTransformAlt(muCur, varcoefCur, _actionLowerBounds[i], _actionUpperBounds[i]);
 
-      const float muOld = oldParamsOne[i];
-      const float varcoefOld = oldParamsTwo[i];
+      const float muOld = oldMeans[i];
+      const float varcoefOld = oldSigmas[i];
 
       float alphaOld;
       float betaOld;

--- a/source/modules/solver/agent/continuous/continuous._hpp
+++ b/source/modules/solver/agent/continuous/continuous._hpp
@@ -21,40 +21,34 @@ class Continuous : public Agent
 
   /**
    * @brief Calculates the gradient of policy wrt to the parameter of the 2nd (current) distribution evaluated at old action.
-   * @param oldAction Action from memory
-   * @param curParamsOne cur means for Normal distribution, beta for Beta distribution
-   * @param curParamsTwo cur sigmas for Normal distribution, alpha for Beta distribution
-   * @param oldParamsOne old means for Normal distribution, beta for Beta distribution
-   * @param oldParamsTwo old sigmas for Normal distribution, alpha for Beta distribution
+   * @param action The action taken by the agent in the given experience
+   * @param oldPolicy The policy for the given state used at the time the action was performed
+   * @param curPolicy The current policy for the given state
    * @return gradient of policy wrt curParamsOne and curParamsTwo
    */
   std::vector<float> calculateImportanceWeightGradient(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy);
 
   /**
    * @brief Calculates the gradient of KL(p_old, p_cur) wrt to the parameter of the 2nd (current) distribution.
-   * @param oldParamsOne old means for Normal distribution, alpha for Beta distribution
-   * @param oldParamsTwo old sigmas for Normal distribution, beta for Beta distribution
-   * @param curParamsOne cur means for Normal distribution, alpha for Beta distribution
-   * @param curParamsTwo cur sigmas for Normal distribution, beta for Beta distribution
-   * @return gradient of KL wrt curParamsOne and curParamsTwo
+   * @param oldPolicy The policy for the given state used at the time the action was performed
+   * @param curPolicy The current policy for the given state
+   * @return
    */
   std::vector<float> calculateKLDivergenceGradient(knlohmann::json &oldPolicy, knlohmann::json &curPolicy);
 
   /**
   * @brief Function to generate randomized actions from neural network output.
-  * @param curMeans parameter vector for policy distribution
-  * @param curSigmas parameter vector for policy distribution
+  * @param curPolicy The current policy for the given state
   * @return An action vector
   */
-  std::vector<float> generateTrainingAction(const std::vector<float> &curMeans, const std::vector<float> &curSigmas);
+  std::vector<float> generateTrainingAction(knlohmann::json &curPolicy);
 
   /**
   * @brief Function to generate deterministic actions from neural network output required for policy evaluation, respectively testing.
-  * @param curMeans parameter vector for policy distribution
-  * @param curSigmas parameter vector for policy distribution
+  * @param curPolicy The current policy for the given state
   * @return An action vector
   */
-  std::vector<float> generateTestingAction(const std::vector<float> &curMeans, const std::vector<float> &curSigmas);
+  std::vector<float> generateTestingAction(knlohmann::json &curPolicy);
 
   float calculateImportanceWeight(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy) override;
   virtual void getAction(korali::Sample &sample) override;

--- a/source/modules/solver/agent/continuous/continuous._hpp
+++ b/source/modules/solver/agent/continuous/continuous._hpp
@@ -67,7 +67,6 @@ class Continuous : public Agent
   */
   std::vector<float> generateTestingAction(const std::vector<float> &curMeans, const std::vector<float> &curSigmas);
 
-  float getExperienceImportanceWeight(size_t expId) override;
   virtual void getAction(korali::Sample &sample) override;
   virtual void initializeAgent();
 };

--- a/source/modules/solver/agent/continuous/continuous._hpp
+++ b/source/modules/solver/agent/continuous/continuous._hpp
@@ -20,17 +20,6 @@ class Continuous : public Agent
   problem::reinforcementLearning::Continuous *_problem;
 
   /**
-   * @brief Calculates importance weight of current action from old and new policies
-   * @param action The action taken
-   * @param curMeans Gaussian means of current policy
-   * @param curSigmas Gaussian sigmas of current policy
-   * @param oldMeans Gaussian means of old policy
-   * @param oldSigmas Gaussian sigmas of old policy
-   * @return The importance weight
-   */
-  float calculateImportanceWeight(const std::vector<float> &action, const std::vector<float> &curMeans, const std::vector<float> &curSigmas, const std::vector<float> &oldMeans, const std::vector<float> &oldSigmas);
-
-  /**
    * @brief Calculates the gradient of policy wrt to the parameter of the 2nd (current) distribution evaluated at old action.
    * @param oldAction Action from memory
    * @param curParamsOne cur means for Normal distribution, beta for Beta distribution
@@ -39,7 +28,7 @@ class Continuous : public Agent
    * @param oldParamsTwo old sigmas for Normal distribution, alpha for Beta distribution
    * @return gradient of policy wrt curParamsOne and curParamsTwo
    */
-  std::vector<float> calculateImportanceWeightGradient(const std::vector<float> &oldAction, const std::vector<float> &curParamsOne, const std::vector<float> &curParamsTwo, const std::vector<float> &oldParamsOne, const std::vector<float> &oldParamsTwo);
+  std::vector<float> calculateImportanceWeightGradient(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy);
 
   /**
    * @brief Calculates the gradient of KL(p_old, p_cur) wrt to the parameter of the 2nd (current) distribution.
@@ -49,7 +38,7 @@ class Continuous : public Agent
    * @param curParamsTwo cur sigmas for Normal distribution, beta for Beta distribution
    * @return gradient of KL wrt curParamsOne and curParamsTwo
    */
-  std::vector<float> calculateKLDivergenceGradient(const std::vector<float> &oldParamsOne, const std::vector<float> &oldParamsTwo, const std::vector<float> &curParamsOne, const std::vector<float> &curParamsTwo);
+  std::vector<float> calculateKLDivergenceGradient(knlohmann::json &oldPolicy, knlohmann::json &curPolicy);
 
   /**
   * @brief Function to generate randomized actions from neural network output.
@@ -67,6 +56,7 @@ class Continuous : public Agent
   */
   std::vector<float> generateTestingAction(const std::vector<float> &curMeans, const std::vector<float> &curSigmas);
 
+  float calculateImportanceWeight(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy) override;
   virtual void getAction(korali::Sample &sample) override;
   virtual void initializeAgent();
 };

--- a/source/modules/solver/agent/discrete/DQN/DQN._cpp
+++ b/source/modules/solver/agent/discrete/DQN/DQN._cpp
@@ -45,11 +45,6 @@ void DQN::initializeAgent()
   _criticPolicyLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_criticPolicyExperiment._solver);
 }
 
-void DQN::updateExperienceMetadata(size_t expId)
-{
- KORALI_LOG_ERROR("To-do.\n");
-}
-
 void DQN::trainPolicy()
 {
   /***********************************************************************************

--- a/source/modules/solver/agent/discrete/DQN/DQN._cpp
+++ b/source/modules/solver/agent/discrete/DQN/DQN._cpp
@@ -85,7 +85,7 @@ void DQN::trainPolicy()
   
     // Compute importance weight
     float importanceWeight = calculateImportanceWeight(expActionIdx, curPvals, expPvals);
-    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
+    _experienceReplay[expId].importanceWeight = importanceWeight;
     */
 
     // Qhat = max_a(qhat) with s' fixed

--- a/source/modules/solver/agent/discrete/DQN/DQN._cpp
+++ b/source/modules/solver/agent/discrete/DQN/DQN._cpp
@@ -45,6 +45,11 @@ void DQN::initializeAgent()
   _criticPolicyLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_criticPolicyExperiment._solver);
 }
 
+void DQN::updateExperienceMetadata(size_t expId)
+{
+ KORALI_LOG_ERROR("To-do.\n");
+}
+
 void DQN::trainPolicy()
 {
   /***********************************************************************************
@@ -76,8 +81,8 @@ void DQN::trainPolicy()
     // Get state, action, and action probabilities from experience
     /*
     auto expStateSequence = getStateTimeSequence(expId);
-    auto expPvals = _experienceReplay[expId].policy["Action Probabilities"].get<std::vector<float>>();
-    size_t expActionIdx = _experienceReplay[expId].policy["Action Index"].get<size_t>();
+    auto expPvals = _experienceReplay[expId].metadata["Action Probabilities"].get<std::vector<float>>();
+    size_t expActionIdx = _experienceReplay[expId].metadata["Action Index"].get<size_t>();
 
     // Forward the neural network for this state to get current action probabilities
     auto policy = runPolicy(expStateSequence);
@@ -85,7 +90,7 @@ void DQN::trainPolicy()
   
     // Compute importance weight
     float importanceWeight = calculateImportanceWeight(expActionIdx, curPvals, expPvals);
-    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
     */
 
     // Qhat = max_a(qhat) with s' fixed

--- a/source/modules/solver/agent/discrete/DQN/DQN._cpp
+++ b/source/modules/solver/agent/discrete/DQN/DQN._cpp
@@ -152,11 +152,11 @@ void DQN::trainPolicy()
     cumulativeQStarSquared += qStar * qStar;
   }
 
-  // Running one generation of the optimization method with the given mini-batch
-  _criticPolicyLearner->runGeneration();
-
   // Updating learning rate for critic/policy learner guided by REFER
   _criticPolicyLearner->_learningRate = _currentLearningRate;
+
+  // Running one generation of the optimization method with the given mini-batch
+  _criticPolicyLearner->runGeneration();
 
   // Keeping statistics
   _statisticsAverageQStar = (float)cumulativeQStar / (float)_miniBatchSize;

--- a/source/modules/solver/agent/discrete/DQN/DQN._hpp
+++ b/source/modules/solver/agent/discrete/DQN/DQN._hpp
@@ -31,6 +31,7 @@ class DQN : public Discrete
    */
   problem::SupervisedLearning *_criticPolicyProblem;
 
+  void updateExperienceMetadata(size_t expId) override;
   float stateValueFunction(const std::vector<std::vector<float>> &state) override;
   void setTrainingState(const knlohmann::json &hyperparameters) override;
   knlohmann::json getTrainingState() override;

--- a/source/modules/solver/agent/discrete/DQN/DQN._hpp
+++ b/source/modules/solver/agent/discrete/DQN/DQN._hpp
@@ -31,7 +31,6 @@ class DQN : public Discrete
    */
   problem::SupervisedLearning *_criticPolicyProblem;
 
-  void updateExperienceMetadata(size_t expId) override;
   float stateValueFunction(const std::vector<std::vector<float>> &state) override;
   void setTrainingState(const knlohmann::json &hyperparameters) override;
   knlohmann::json getTrainingState() override;

--- a/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
+++ b/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
@@ -87,6 +87,10 @@ void dVRACER::trainPolicy()
     float importanceWeight = calculateImportanceWeight(expActionIdx, curPvals, expPvals);
     _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
 
+    // Important: store computed information for use in retrace.
+    _experienceReplay[expId].policy["State Value"] = V;
+    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+
     /******************************************************
     * Gradient calculation
     *******************************************************/

--- a/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
+++ b/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
@@ -83,7 +83,6 @@ void dVRACER::trainPolicy()
     // Gathering metadata
     float V = _experienceReplay[expId].stateValue;
     auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
-    float importanceWeight = _experienceReplay[expId].importanceWeight;
     float expVtbc = _experienceReplay[expId].retraceValue;
     auto curActionProbabilities = curPolicy["Action Probabilities"].get<std::vector<float>>();
 
@@ -107,11 +106,8 @@ void dVRACER::trainPolicy()
     cumulativeTdError -= (V - expVtbc);
     cumulativeTdErrorSquared += gradientLoss[0] * gradientLoss[0];
 
-    // Checking whether the experience is on policy (i.e., it is within the [1/cutoff, cutoff] region)
-    bool isOnPolicy = (importanceWeight > (1.0f / _experienceReplayOffPolicyCurrentCutoff)) && (importanceWeight < _experienceReplayOffPolicyCurrentCutoff);
-
     // Compute policy gradient only if inside trust region
-    if (isOnPolicy)
+    if (_experienceReplay[expId].isOnPolicy)
     {
       // Qret for terminal state is just reward
       float Qret = _experienceReplay[expId].reward;

--- a/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
+++ b/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
@@ -46,6 +46,11 @@ void dVRACER::initializeAgent()
   _criticPolicyLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_criticPolicyExperiment._solver);
 }
 
+void dVRACER::updateExperienceMetadata(size_t expId)
+{
+ KORALI_LOG_ERROR("To-do.\n");
+}
+
 void dVRACER::trainPolicy()
 {
   // Resetting statistics
@@ -75,8 +80,8 @@ void dVRACER::trainPolicy()
 
     // Get state, action, and action probabilities from experience
     auto expStateSequence = getStateTimeSequence(expId);
-    auto expPvals = _experienceReplay[expId].policy["Action Probabilities"].get<std::vector<float>>();
-    size_t expActionIdx = _experienceReplay[expId].policy["Action Index"].get<size_t>();
+    auto expPvals = _experienceReplay[expId].metadata["Action Probabilities"].get<std::vector<float>>();
+    size_t expActionIdx = _experienceReplay[expId].metadata["Action Index"].get<size_t>();
 
     // Forward the neural network for this state to get current action probabilities
     auto policy = runPolicy(expStateSequence);
@@ -85,11 +90,11 @@ void dVRACER::trainPolicy()
 
     // Compute importance weight
     float importanceWeight = calculateImportanceWeight(expActionIdx, curPvals, expPvals);
-    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
 
     // Important: store computed information for use in retrace.
-    _experienceReplay[expId].policy["State Value"] = V;
-    _experienceReplay[expId].policy["Importance Weight"] = importanceWeight;
+    _experienceReplay[expId].metadata["State Value"] = V;
+    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
 
     /******************************************************
     * Gradient calculation

--- a/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
+++ b/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
@@ -89,7 +89,7 @@ void dVRACER::trainPolicy()
     auto V = policy["State Value"].get<float>();
 
     // Compute importance weight
-    float importanceWeight = calculateImportanceWeight(expActionIdx, curPvals, expPvals);
+    float importanceWeight = 0.0f;//calculateImportanceWeight(expActionIdx, curPvals, expPvals);
     _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
 
     // Important: store computed information for use in retrace.
@@ -160,7 +160,7 @@ void dVRACER::trainPolicy()
       policyErrorCounter++;
 
       // Compute Policy Gradient wrt Params
-      auto polGrad = calculateImportanceWeightGradient(expActionIdx, curPvals, expPvals);
+      std::vector<float> polGrad;//calculateImportanceWeightGradient(expActionIdx, curPvals, expPvals);
 
       // Set Gradient of Loss wrt Params
       for (size_t i = 0; i < _problem->_possibleActions.size(); i++)
@@ -171,7 +171,7 @@ void dVRACER::trainPolicy()
     }
 
     // Compute derivative of kullback-leibler divergence wrt current distribution params
-    auto klGrad = calculateKLDivergenceGradient(expPvals, curPvals);
+    std::vector<float> klGrad; //calculateKLDivergenceGradient(expPvals, curPvals);
 
     for (size_t i = 0; i < _problem->_possibleActions.size(); i++)
     {
@@ -221,9 +221,6 @@ knlohmann::json dVRACER::runPolicy(const std::vector<std::vector<float>> &state)
   // Forward the neural network for this state
   std::vector<float> evaluation = _criticPolicyLearner->getEvaluation({state})[0];
 
-  // Get state value
-  auto stateValue = evaluation[0];
-
   // Storage for action probabilities
   float maxq = -korali::Inf;
   std::vector<float> qval(_problem->_possibleActions.size());
@@ -263,8 +260,7 @@ knlohmann::json dVRACER::runPolicy(const std::vector<std::vector<float>> &state)
 
   // Returning action probabilities along with state value and importance weight
   knlohmann::json policy;
-  policy["State Value"] = stateValue;
-  policy["Action Probabilities"] = pActions;
+  policy["Current Policy"]["Action Probabilities"] = pActions;
 
   return policy;
 }

--- a/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
+++ b/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
@@ -81,14 +81,14 @@ void dVRACER::trainPolicy()
     auto expActionProbabilities = expPolicy["Action Probabilities"].get<std::vector<float>>();
 
     // Gathering metadata
-    float V = _experienceReplay[expId].metadata["State Value"];
+    float V = _experienceReplay[expId].stateValue;
     auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
-    float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
-    float expVtbc = _experienceReplay[expId].metadata["Retrace Value"];
+    float importanceWeight = _experienceReplay[expId].importanceWeight;
+    float expVtbc = _experienceReplay[expId].retraceValue;
     auto curActionProbabilities = curPolicy["Action Probabilities"].get<std::vector<float>>();
 
     // Gathering policyInformation
-    V = _experienceReplay[expId].metadata["State Value"];
+    V = _experienceReplay[expId].stateValue;
 
     /******************************************************
     * Gradient calculation
@@ -132,13 +132,7 @@ void dVRACER::trainPolicy()
       // For truncated state add value
       if (isTrucated == true)
       {
-        // Get truncated state sequence, adding the truncated state to it and removing first time element
-        auto expTruncatedStateSequence = getTruncatedStateTimeSequence(expId);
-
-        // for truncated state, Vtbc == V - forward network
-        float nextExpVtbc = stateValueFunction(expTruncatedStateSequence);
-
-        // add value to Qret
+        float nextExpVtbc = _experienceReplay[expId].truncatedStateValue;
         Qret += _discountFactor * nextExpVtbc;
       }
 

--- a/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
+++ b/source/modules/solver/agent/discrete/dVRACER/dVRACER._cpp
@@ -46,11 +46,6 @@ void dVRACER::initializeAgent()
   _criticPolicyLearner = dynamic_cast<solver::learner::DeepSupervisor *>(_criticPolicyExperiment._solver);
 }
 
-void dVRACER::updateExperienceMetadata(size_t expId)
-{
- KORALI_LOG_ERROR("To-do.\n");
-}
-
 void dVRACER::trainPolicy()
 {
   // Resetting statistics
@@ -78,30 +73,26 @@ void dVRACER::trainPolicy()
     // Getting index of current experiment
     size_t expId = miniBatchIndexes[b];
 
-    // Get state, action, and action probabilities from experience
+    // Get state, action and policy for this experience
     auto expStateSequence = getStateTimeSequence(expId);
-    auto expPvals = _experienceReplay[expId].metadata["Action Probabilities"].get<std::vector<float>>();
-    size_t expActionIdx = _experienceReplay[expId].metadata["Action Index"].get<size_t>();
+    auto expPolicy = _experienceReplay[expId].metadata["Experience Policy"];
+    auto expAction = _experienceReplay[expId].action;
+    auto expActionIdx = expPolicy["Action Index"].get<float>();
+    auto expActionProbabilities = expPolicy["Action Probabilities"].get<std::vector<float>>();
 
-    // Forward the neural network for this state to get current action probabilities
-    auto policy = runPolicy(expStateSequence);
-    auto curPvals = policy["Action Probabilities"].get<std::vector<float>>();
-    auto V = policy["State Value"].get<float>();
+    // Gathering metadata
+    float V = _experienceReplay[expId].metadata["State Value"];
+    auto curPolicy = _experienceReplay[expId].metadata["Current Policy"];
+    float importanceWeight = _experienceReplay[expId].metadata["Importance Weight"];
+    float expVtbc = _experienceReplay[expId].metadata["Retrace Value"];
+    auto curActionProbabilities = curPolicy["Action Probabilities"].get<std::vector<float>>();
 
-    // Compute importance weight
-    float importanceWeight = 0.0f;//calculateImportanceWeight(expActionIdx, curPvals, expPvals);
-    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
-
-    // Important: store computed information for use in retrace.
-    _experienceReplay[expId].metadata["State Value"] = V;
-    _experienceReplay[expId].metadata["Importance Weight"] = importanceWeight;
+    // Gathering policyInformation
+    V = _experienceReplay[expId].metadata["State Value"];
 
     /******************************************************
     * Gradient calculation
     *******************************************************/
-
-    // Get Vtbc before update
-    float expVtbc = retraceFunction(expId);
 
     // Storage for the update gradient
     std::vector<float> gradientLoss(1 + _problem->_possibleActions.size());
@@ -145,8 +136,7 @@ void dVRACER::trainPolicy()
         auto expTruncatedStateSequence = getTruncatedStateTimeSequence(expId);
 
         // for truncated state, Vtbc == V - forward network
-        auto policy = runPolicy(expTruncatedStateSequence);
-        float nextExpVtbc = policy["State Value"].get<float>();
+        float nextExpVtbc = stateValueFunction(expTruncatedStateSequence);
 
         // add value to Qret
         Qret += _discountFactor * nextExpVtbc;
@@ -160,7 +150,7 @@ void dVRACER::trainPolicy()
       policyErrorCounter++;
 
       // Compute Policy Gradient wrt Params
-      std::vector<float> polGrad;//calculateImportanceWeightGradient(expActionIdx, curPvals, expPvals);
+      auto polGrad = calculateImportanceWeightGradient(expActionIdx, curActionProbabilities, expActionProbabilities);
 
       // Set Gradient of Loss wrt Params
       for (size_t i = 0; i < _problem->_possibleActions.size(); i++)
@@ -171,7 +161,7 @@ void dVRACER::trainPolicy()
     }
 
     // Compute derivative of kullback-leibler divergence wrt current distribution params
-    std::vector<float> klGrad; //calculateKLDivergenceGradient(expPvals, curPvals);
+    std::vector<float> klGrad = calculateKLDivergenceGradient(expActionProbabilities, curActionProbabilities);
 
     for (size_t i = 0; i < _problem->_possibleActions.size(); i++)
     {
@@ -212,14 +202,17 @@ void dVRACER::trainPolicy()
 float dVRACER::stateValueFunction(const std::vector<std::vector<float>> &state)
 {
   // Calculating V(s_i)
-  float v = _criticPolicyLearner->getEvaluation({state})[0][0];
-  return v;
+  float V = _criticPolicyLearner->getEvaluation({state})[0][0];
+  return V;
 }
 
 knlohmann::json dVRACER::runPolicy(const std::vector<std::vector<float>> &state)
 {
   // Forward the neural network for this state
   std::vector<float> evaluation = _criticPolicyLearner->getEvaluation({state})[0];
+
+  // Getting state value
+  float V = evaluation[0];
 
   // Storage for action probabilities
   float maxq = -korali::Inf;
@@ -260,7 +253,8 @@ knlohmann::json dVRACER::runPolicy(const std::vector<std::vector<float>> &state)
 
   // Returning action probabilities along with state value and importance weight
   knlohmann::json policy;
-  policy["Current Policy"]["Action Probabilities"] = pActions;
+  policy["State Value"] = V;
+  policy["Action Probabilities"] = pActions;
 
   return policy;
 }

--- a/source/modules/solver/agent/discrete/dVRACER/dVRACER._hpp
+++ b/source/modules/solver/agent/discrete/dVRACER/dVRACER._hpp
@@ -30,6 +30,7 @@ class dVRACER : public Discrete
    */
   problem::SupervisedLearning *_criticPolicyProblem;
 
+  void updateExperienceMetadata(size_t expId) override;
   float stateValueFunction(const std::vector<std::vector<float>> &state) override;
   void setTrainingState(const knlohmann::json &state) override;
   knlohmann::json getTrainingState() override;

--- a/source/modules/solver/agent/discrete/dVRACER/dVRACER._hpp
+++ b/source/modules/solver/agent/discrete/dVRACER/dVRACER._hpp
@@ -30,7 +30,6 @@ class dVRACER : public Discrete
    */
   problem::SupervisedLearning *_criticPolicyProblem;
 
-  void updateExperienceMetadata(size_t expId) override;
   float stateValueFunction(const std::vector<std::vector<float>> &state) override;
   void setTrainingState(const knlohmann::json &state) override;
   knlohmann::json getTrainingState() override;

--- a/source/modules/solver/agent/discrete/discrete._cpp
+++ b/source/modules/solver/agent/discrete/discrete._cpp
@@ -62,11 +62,6 @@ void Discrete::getAction(korali::Sample &sample)
       // NOTE: In original DQN paper [Minh2015] we choose max
       // actionIdx = std::distance(pActions.begin(), std::max_element(pActions.begin(), pActions.end()));
     }
-
-    // Storing action idx, policy and importance weight
-    sample["Policy"] = policy;
-    sample["Policy"]["Importance Weight"] = 1.0f;
-    sample["Policy"]["Action Index"] = actionIdx;
   }
 
   /*****************************************************************************
@@ -76,9 +71,7 @@ void Discrete::getAction(korali::Sample &sample)
 
   // Finding the best action index from the probabilities
   if (sample["Mode"] == "Testing")
-  {
     actionIdx = std::distance(pActions.begin(), std::max_element(pActions.begin(), pActions.end()));
-  }
 
   /*****************************************************************************
   * Storing the action itself
@@ -93,6 +86,9 @@ void Discrete::getAction(korali::Sample &sample)
     actionIdx = _problem->_possibleActions.size() - 1;
   }
 
+  // Storing action itself, its idx, and probabilities
+  sample["Metadata"]["Action Probabilities"] = pActions;
+  sample["Metadata"]["Action Index"] = actionIdx;
   sample["Action"] = _problem->_possibleActions[actionIdx];
 }
 
@@ -108,26 +104,6 @@ float Discrete::calculateImportanceWeight(const size_t actionIdx, const std::vec
   float importanceWeight = pCurPolicy / pOldPolicy;
 
   return importanceWeight;
-}
-
-float Discrete::getExperienceImportanceWeight(size_t expId)
-{
-  // Getting the state sequence and action index for the given experience
-  auto expStateSequence = getStateTimeSequence(expId);
-  auto expActionIdx = _experienceReplay[expId].policy["Action Index"].get<size_t>();
-
-  // Get action probabilities for the policy used for the experience
-  auto expPvals = _experienceReplay[expId].policy["Action Probabilities"].get<std::vector<float>>();
-
-  // Getting current policy and calculating its action probabilities
-  auto policy = runPolicy(expStateSequence);
-  auto curPvals = policy["Action Probabilities"].get<std::vector<float>>();
-
-  // Now calculating importance weight
-  auto expImportanceWeight = calculateImportanceWeight(expActionIdx, curPvals, expPvals);
-
-  // Returning experience's importance weight
-  return expImportanceWeight;
 }
 
 std::vector<float> Discrete::calculateImportanceWeightGradient(size_t actionIdx, const std::vector<float> &curPvals, const std::vector<float> &oldPvals)

--- a/source/modules/solver/agent/discrete/discrete._cpp
+++ b/source/modules/solver/agent/discrete/discrete._cpp
@@ -87,18 +87,22 @@ void Discrete::getAction(korali::Sample &sample)
   }
 
   // Storing action itself, its idx, and probabilities
-  sample["Metadata"]["Action Probabilities"] = pActions;
-  sample["Metadata"]["Action Index"] = actionIdx;
+  sample["Metadata"]["Experience Policy"]["Action Probabilities"] = pActions;
+  sample["Metadata"]["Experience Policy"]["Action Index"] = actionIdx;
   sample["Action"] = _problem->_possibleActions[actionIdx];
 }
 
-float Discrete::calculateImportanceWeight(const size_t actionIdx, const std::vector<float> &curProbabilities, const std::vector<float> &oldProbabilities)
+float Discrete::calculateImportanceWeight(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy)
 {
+  auto pVectorCurPolicy = curPolicy["Action Probabilities"].get<std::vector<float>>();
+  auto pVectorOldPolicy = oldPolicy["Action Probabilities"].get<std::vector<float>>();
+  auto actionIdx = oldPolicy["Action Index"].get<size_t>();
+
   // Getting probability density of action for current policy
-  float pCurPolicy = curProbabilities[actionIdx];
+  float pCurPolicy = pVectorCurPolicy[actionIdx];
 
   // Getting probability density of action for old policy
-  float pOldPolicy = oldProbabilities[actionIdx];
+  float pOldPolicy = pVectorOldPolicy[actionIdx];
 
   // Now calculating importance weight for the old s,a experience
   float importanceWeight = pCurPolicy / pOldPolicy;

--- a/source/modules/solver/agent/discrete/discrete._hpp
+++ b/source/modules/solver/agent/discrete/discrete._hpp
@@ -18,14 +18,7 @@ class Discrete : public Agent
  */
   problem::reinforcementLearning::Discrete *_problem;
 
-  /**
-   * @brief Calculates importance weight of current action from old and current policies
-   * @param actionIdx Index of the action taken
-   * @param curProbabilities Probability distributions of current policy
-   * @param oldProbabilities Probability distributions of old policy
-   * @return The importance weight
-   */
-  float calculateImportanceWeight(const size_t actionIdx, const std::vector<float> &curProbabilities, const std::vector<float> &oldProbabilities);
+  float calculateImportanceWeight(const std::vector<float> &action, knlohmann::json &curPolicy, knlohmann::json &oldPolicy) override;
 
   /**
    * @brief Calculates the gradient of importance weight wrt to NN output

--- a/source/modules/solver/agent/discrete/discrete._hpp
+++ b/source/modules/solver/agent/discrete/discrete._hpp
@@ -44,7 +44,6 @@ class Discrete : public Agent
    */
   std::vector<float> calculateKLDivergenceGradient(const std::vector<float> &oldPvalues, const std::vector<float> &curPvalues);
 
-  float getExperienceImportanceWeight(size_t expId) override;
   void getAction(korali::Sample &sample) override;
   virtual void initializeAgent();
 };

--- a/source/modules/solver/learner/deepSupervisor/deepSupervisor._cpp
+++ b/source/modules/solver/learner/deepSupervisor/deepSupervisor._cpp
@@ -74,7 +74,7 @@ void DeepSupervisor::initialize()
   {
     auto inferenceNeuralNetworkConfig = neuralNetworkConfig;
     inferenceNeuralNetworkConfig["Batch Size"] = _problem->_inferenceBatchSize;
-    inferenceNeuralNetworkConfig["Mode"] = "Inference";
+    inferenceNeuralNetworkConfig["Mode"] = "Training";
     _inferenceNeuralNetworks[i] = dynamic_cast<NeuralNetwork *>(getModule(inferenceNeuralNetworkConfig, _k));
     _inferenceNeuralNetworks[i]->applyModuleDefaults(inferenceNeuralNetworkConfig);
     _inferenceNeuralNetworks[i]->setConfiguration(inferenceNeuralNetworkConfig);
@@ -245,6 +245,20 @@ std::vector<std::vector<float>> DeepSupervisor::getEvaluation(const std::vector<
 
   // Returning the output values for the last given timestep
   return _inferenceNeuralNetworks[curThread]->_outputValues;
+}
+
+std::vector<std::vector<float>> DeepSupervisor::getDataGradients(const std::vector<std::vector<std::vector<float>>> &input, const std::vector<std::vector<float>> &outputGradients)
+{
+  // Getting current thread ID
+  size_t curThread = omp_get_thread_num();
+
+  auto forwardEvaluation = getEvaluation(input);
+
+  // Running the input values through the neural network
+  _inferenceNeuralNetworks[curThread]->backward(outputGradients);
+
+  // Returning the input data gradients
+  return _inferenceNeuralNetworks[curThread]->_inputGradients;
 }
 
 void DeepSupervisor::printGenerationAfter()

--- a/source/modules/solver/learner/deepSupervisor/deepSupervisor._hpp
+++ b/source/modules/solver/learner/deepSupervisor/deepSupervisor._hpp
@@ -43,8 +43,15 @@ class DeepSupervisor : public Learner
    */
   std::vector<NeuralNetwork *> _inferenceNeuralNetworks;
 
-  std::vector<std::vector<float>> getEvaluation(const std::vector<std::vector<std::vector<float>>> &input) override;
+  /**
+    * @brief Calculates the gradients with respect to the inputs (data), given an input and output gradients
+    * @param input The inputs from which to infer outputs. Format: BxTxIC (B: Batch Size, T: Time steps, IC: Input channels)
+    * @param outputGradients The output gradients. Format: BxOC (B: Batch Size, OC: Input channels)
+    * @return The inferred batch input gradients Format: BxIC (B: Batch Size, IC: Output channels)
+   */
+  std::vector<std::vector<float>> getDataGradients(const std::vector<std::vector<std::vector<float>>> &input, const std::vector<std::vector<float>> &outputGradients);
 
+  std::vector<std::vector<float>> getEvaluation(const std::vector<std::vector<std::vector<float>>> &input) override;
   std::vector<float> getTrainingHyperparameters() override;
   void setTrainingHyperparameters(const std::vector<float> &hyperparameters) override;
   std::vector<float> getInferenceHyperparameters() override;

--- a/tools/rlview/__main__.py
+++ b/tools/rlview/__main__.py
@@ -28,6 +28,9 @@ def plotRewardHistory(ax, dirs, results, minReward, maxReward, averageDepth, max
  maxPlotReward = -math.inf
  minPlotReward = +math.inf
 
+ ## Creating colormap
+ cmap = matplotlib.cm.get_cmap('viridis', len(results))
+
  ## Plotting the individual experiment results
     
  for resId, r in enumerate(results):
@@ -76,10 +79,9 @@ def plotRewardHistory(ax, dirs, results, minReward, maxReward, averageDepth, max
   confIntervalHistory = np.array(confIntervalHistory)
 
   # Plotting common plot
-  clr='red'
-  if ('GFPT' in dirs[resId]): clr='blue'    
   epList = range(0, len(rewardHistory)) 
-  ax.plot(epList, meanHistory, '-', label=str(averageDepth) + '-Episode Average (' + dirs[resId] + ')', color=clr)
+  ax.plot(epList, rewardHistory, 'x', markersize=1.3, color=cmap.colors[resId])
+  ax.plot(epList, meanHistory, '-', label=str(averageDepth) + '-Episode Average (' + dirs[resId] + ')', color=cmap.colors[resId])
   
  ## Configuring common plotting features
  
@@ -126,6 +128,7 @@ def parseResults(dir):
   genList = [ ]
  
   for file in resultFiles:
+   if (not 'aux' in file):
     with open(p + '/' + file) as f:
       genJs = json.load(f)
       solverRunId = genJs['Run ID']


### PR DESCRIPTION
- Full smarties-like retrace. It is fully general, no algorithm-specific stuff
- generateMinibatch now updates all relevant info about the experience (policy, V, Vret, rho), no need to re-calculate this in the algorithm. It also updates vret.
- added DDPG
- Some work on GFPT
- Performance optimizations everywhere
- Cleaning up coding in continuous._cpp