### PR TITLE
Retrace fix

### DIFF
--- a/source/modules/solver/agent/agent._cpp
+++ b/source/modules/solver/agent/agent._cpp
@@ -610,9 +610,9 @@ std::vector<size_t> Agent::generateMiniBatch(size_t miniBatchSize)
     }
   }
 
-  // Passing the content of the map to a vector
+  // Passing the values (experience Ids) of the map to a vector
   std::vector<size_t> experienceRetraceIds;
-  for (const auto &expId : episodeMaxExperienceId) experienceRetraceIds.push_back(expId.first);
+  for (const auto &episode : episodeMaxExperienceId) experienceRetraceIds.push_back(episode.second);
 
 // Running all experiences in parallel
 #pragma omp parallel for schedule(dynamic, 1)

--- a/source/modules/solver/agent/agent.config
+++ b/source/modules/solver/agent/agent.config
@@ -157,7 +157,7 @@
   {
     "Name": [ "Max Experiences" ],
     "Type": "size_t",
-    "Criteria": "(_mode == \"Training\") && (_maxExperiences > 0) && (_experienceReplay.size() >= _maxExperiences)",
+    "Criteria": "(_mode == \"Training\") && (_maxExperiences > 0) && (_experienceCount >= _maxExperiences)",
     "Description": "The solver will stop when the given number of experiences have been gathered."
   },
   {


### PR DESCRIPTION
I fixed the retrace function, the vector was filled with the episode  Ids and not experience Ids.
I merged with the fix-experience branch, which includes another fix