### PR TITLE
Rl restart fix

### DIFF
--- a/examples/features/checkpoint.resume/run-vracer.py
+++ b/examples/features/checkpoint.resume/run-vracer.py
@@ -19,14 +19,14 @@ if (found == False):
   print('------------------------------------------------------')
   print('Running first 5 generations...')
   print('------------------------------------------------------')
-  e["Solver"]["Termination Criteria"]["Max Generations"] = 5
+  e["Solver"]["Termination Criteria"]["Max Generations"] = 80
 
 # If found, we continue 
 if (found == True):
   print('------------------------------------------------------')
   print('Running 5 more generations...')
   print('------------------------------------------------------')
-  e["Solver"]["Termination Criteria"]["Max Generations"] = e["Current Generation"] + 5
+  e["Solver"]["Termination Criteria"]["Max Generations"] = e["Current Generation"] + 80
   
 ### Defining the Cartpole problem's configuration
 
@@ -56,8 +56,8 @@ e["Variables"][4]["Initial Exploration Noise"] = 1.0
 e["Solver"]["Type"] = "Agent / Continuous / VRACER"
 e["Solver"]["Mode"] = "Training"
 e["Solver"]["Episodes Per Generation"] = 1
-e["Solver"]["Experiences Between Policy Updates"] = 10
-e["Solver"]["Learning Rate"] = 0.0001
+e["Solver"]["Experiences Between Policy Updates"] = 1
+e["Solver"]["Learning Rate"] = 0.005
 e["Solver"]["Experience Replay"]["Start Size"] = 1000
 e["Solver"]["Experience Replay"]["Maximum Size"] = 10000
 e["Solver"]["Mini Batch"]["Size"] = 32
@@ -88,7 +88,7 @@ e["Solver"]["Termination Criteria"]["Testing"]["Target Average Reward"] = 450
 e["Console Output"]["Verbosity"] = "Detailed"
 e["File Output"]["Path"] = "_result_vracer"
 e["File Output"]["Enabled"] = True
-e["File Output"]["Frequency"] = 1
+e["File Output"]["Frequency"] = 5
  
 ### Running Training Experiment
 

--- a/examples/hierarchical.bayesian/basic/run-phase3b.py
+++ b/examples/hierarchical.bayesian/basic/run-phase3b.py
@@ -7,14 +7,14 @@ import korali
 
 # Creating hierarchical Bayesian problem from previous two problems
 e = korali.Experiment()
-theta = korali.Experiment()
+sub = korali.Experiment()
 psi = korali.Experiment()
 
-theta.loadState('_setup/results_phase_1/000/latest')
+sub.loadState('_setup/results_phase_1/000/latest')
 psi.loadState('_setup/results_phase_2/latest')
 
 e["Problem"]["Type"] = "Hierarchical/Theta"
-e["Problem"]["Theta Experiment"] = theta
+e["Problem"]["Sub Experiment"] = sub
 e["Problem"]["Psi Experiment"] = psi
 
 e["Solver"]["Type"] = "Sampler/TMCMC"

--- a/examples/hierarchical.bayesian/basic/run-phase3b.py
+++ b/examples/hierarchical.bayesian/basic/run-phase3b.py
@@ -4,6 +4,8 @@
 import sys
 import os
 import korali
+sys.path.append('_setup/model')
+from model import *
 
 # Creating hierarchical Bayesian problem from previous two problems
 e = korali.Experiment()
@@ -13,9 +15,13 @@ psi = korali.Experiment()
 sub.loadState('_setup/results_phase_1/000/latest')
 psi.loadState('_setup/results_phase_2/latest')
 
+data = getReferenceData("_setup/data/", 0)
+N = len(data)
+  
 e["Problem"]["Type"] = "Hierarchical/Theta"
 e["Problem"]["Sub Experiment"] = sub
 e["Problem"]["Psi Experiment"] = psi
+e["Problem"]["Sub Experiment Model"] = lambda d: normal(N,d)
 
 e["Solver"]["Type"] = "Sampler/TMCMC"
 e["Solver"]["Population Size"] = 1000

--- a/examples/hierarchical.bayesian/extended/run-phase3b.py
+++ b/examples/hierarchical.bayesian/extended/run-phase3b.py
@@ -12,12 +12,14 @@ e = korali.Experiment()
 theta = korali.Experiment()
 psi = korali.Experiment()
 
+x = getReferencePoints("_setup/data/", 0)
 theta.loadState('_setup/results_phase_1/000/latest')
 psi.loadState('_setup/results_phase_2/latest')
 
 e["Problem"]["Type"] = "Hierarchical/Theta"
-e["Problem"]["Theta Experiment"] = theta
 e["Problem"]["Psi Experiment"] = psi
+e["Problem"]["Sub Experiment"] = theta
+e["Problem"]["Sub Experiment Model"] = lambda d: logistic(x, d)
 
 e["Solver"]["Type"] = "Sampler/TMCMC"
 e["Solver"]["Population Size"] = 1000

--- a/source/modules/problem/hierarchical/theta/theta.config
+++ b/source/modules/problem/hierarchical/theta/theta.config
@@ -18,6 +18,11 @@
     "Name": [ "Psi Experiment" ],
     "Type": "knlohmann::json",
     "Description": "Results from the hierarchical problem (Psi)."
+   },
+   {
+    "Name": [ "Sub Experiment Model" ],
+    "Type": "std::function<void(korali::Sample&)>",
+    "Description": "Stores the a function used by the underlying Bayesian problem, if required."
    }
  ]
 }

--- a/source/modules/problem/hierarchical/theta/theta.config
+++ b/source/modules/problem/hierarchical/theta/theta.config
@@ -10,9 +10,9 @@
  "Configuration Settings":
  [
    {
-    "Name": [ "Theta Experiment" ],
+    "Name": [ "Sub Experiment" ],
     "Type": "knlohmann::json",
-    "Description": "Results from one previous Korali execution."
+    "Description": "Results from one previously executed Bayesian experiment."
    },
    {
     "Name": [ "Psi Experiment" ],

--- a/source/modules/problem/hierarchical/theta/theta.cpp
+++ b/source/modules/problem/hierarchical/theta/theta.cpp
@@ -89,6 +89,15 @@ void Theta::initialize()
     _precomputedLogDenominator.push_back(localSum);
   }
 
+  // Now inheriting Sub problem's variables and distributions
+  _k->_variables.clear();
+  for (size_t i = 0; i < _subExperimentObject._variables.size(); i++)
+   _k->_variables.push_back(_subExperimentObject._variables[i]);
+
+  _k->_distributions.clear();
+  for (size_t i = 0; i < _subExperimentObject._distributions.size(); i++)
+    _k->_distributions.push_back(_subExperimentObject._distributions[i]);
+
   Hierarchical::initialize();
 }
 
@@ -141,6 +150,15 @@ void Theta::setConfiguration(knlohmann::json& js)
  }
   else   KORALI_LOG_ERROR(" + No value provided for mandatory setting: ['Psi Experiment'] required by theta.\n"); 
 
+ if (isDefined(js, "Sub Experiment Model"))
+ {
+ try { _subExperimentModel = js["Sub Experiment Model"].get<std::uint64_t>();
+} catch (const std::exception& e)
+ { KORALI_LOG_ERROR(" + Object: [ theta ] \n + Key:    ['Sub Experiment Model']\n%s", e.what()); } 
+   eraseValue(js, "Sub Experiment Model");
+ }
+  else   KORALI_LOG_ERROR(" + No value provided for mandatory setting: ['Sub Experiment Model'] required by theta.\n"); 
+
  Hierarchical::setConfiguration(js);
  _type = "hierarchical/theta";
  if(isDefined(js, "Type")) eraseValue(js, "Type");
@@ -153,6 +171,7 @@ void Theta::getConfiguration(knlohmann::json& js)
  js["Type"] = _type;
    js["Sub Experiment"] = _subExperiment;
    js["Psi Experiment"] = _psiExperiment;
+   js["Sub Experiment Model"] = _subExperimentModel;
  Hierarchical::getConfiguration(js);
 } 
 

--- a/source/modules/problem/hierarchical/theta/theta.cpp
+++ b/source/modules/problem/hierarchical/theta/theta.cpp
@@ -12,25 +12,21 @@ namespace hierarchical
 
 void Theta::initialize()
 {
+
+  // Psi Experiment
+
   // Setting experiment configurations to actual korali experiments
   _psiExperimentObject._js.getJson() = _psiExperiment;
-  _thetaExperimentObject._js.getJson() = _thetaExperiment;
 
   // Running initialization to verify that the configuration is correct
   _psiExperimentObject.initialize();
-  _thetaExperimentObject.initialize();
 
   _psiProblem = dynamic_cast<Psi *>(_psiExperimentObject._problem);
   if (_psiProblem == NULL) KORALI_LOG_ERROR("Psi experiment passed is not of type Hierarchical/Psi\n");
 
-  if (_thetaExperiment["Is Finished"] == false)
-    KORALI_LOG_ERROR("The Hierarchical Bayesian (Theta) requires that the theta problem has run completely, but this one has not.\n");
-
   // Now inheriting Sub problem's variables
-  _k->_distributions = _thetaExperimentObject._distributions;
-  _k->_variables = _thetaExperimentObject._variables;
-
-  _thetaVariableCount = _thetaExperimentObject._variables.size();
+  _k->_distributions = _subExperimentObject._distributions;
+  _k->_variables = _subExperimentObject._variables;
   _psiVariableCount = _psiExperimentObject._variables.size();
 
   // Loading Psi problem results
@@ -46,21 +42,29 @@ void Theta::initialize()
       KORALI_LOG_ERROR("Non finite (%lf) prior has been detected at sample %zu in Psi problem.\n", expPrior, i);
   }
 
-  // Loading Theta problem results
-  _thetaProblemSampleCount = _thetaExperiment["Solver"]["Chain Leaders LogLikelihoods"].size();
-  _thetaProblemSampleLogLikelihoods = _thetaExperiment["Solver"]["Sample LogLikelihood Database"].get<std::vector<double>>();
-  _thetaProblemSampleLogPriors = _thetaExperiment["Solver"]["Sample LogPrior Database"].get<std::vector<double>>();
-  _thetaProblemSampleCoordinates = _thetaExperiment["Solver"]["Sample Database"].get<std::vector<std::vector<double>>>();
+  /// Sub Experiment
+  if (_subExperiment["Is Finished"] == false)
+    KORALI_LOG_ERROR("The Hierarchical Bayesian (Theta) requires that the sub problem has run completely, but this one has not.\n");
 
-  for (size_t i = 0; i < _thetaProblemSampleLogPriors.size(); i++)
+  _subExperimentObject._js.getJson() = _subExperiment;
+  _subExperimentObject.initialize();
+  _subProblemVariableCount = _subExperimentObject._variables.size();
+
+  // Loading Theta problem results
+  _subProblemSampleCount = _subExperiment["Solver"]["Chain Leaders LogLikelihoods"].size();
+  _subProblemSampleLogLikelihoods = _subExperiment["Solver"]["Sample LogLikelihood Database"].get<std::vector<double>>();
+  _subProblemSampleLogPriors = _subExperiment["Solver"]["Sample LogPrior Database"].get<std::vector<double>>();
+  _subProblemSampleCoordinates = _subExperiment["Solver"]["Sample Database"].get<std::vector<std::vector<double>>>();
+
+  for (size_t i = 0; i < _subProblemSampleLogPriors.size(); i++)
   {
-    double expPrior = exp(_thetaProblemSampleLogPriors[i]);
+    double expPrior = exp(_subProblemSampleLogPriors[i]);
     if (std::isfinite(expPrior) == false)
-      KORALI_LOG_ERROR("Non finite (%lf) prior has been detected at sample %zu in Theta problem.\n", expPrior, i);
+      KORALI_LOG_ERROR("Non finite (%lf) prior has been detected at sample %zu in sub problem.\n", expPrior, i);
   }
 
   std::vector<double> logValues;
-  logValues.resize(_thetaProblemSampleCount);
+  logValues.resize(_subProblemSampleCount);
 
   _psiProblem = dynamic_cast<Psi *>(_psiProblem);
 
@@ -71,16 +75,16 @@ void Theta::initialize()
 
     _psiProblem->updateConditionalPriors(psiSample);
 
-    for (size_t j = 0; j < _thetaProblemSampleCount; j++)
+    for (size_t j = 0; j < _subProblemSampleCount; j++)
     {
       double logConditionalPrior = 0;
-      for (size_t k = 0; k < _thetaVariableCount; k++)
-        logConditionalPrior += _psiExperimentObject._distributions[_psiProblem->_conditionalPriorIndexes[k]]->getLogDensity(_thetaProblemSampleCoordinates[j][k]);
+      for (size_t k = 0; k < _subProblemVariableCount; k++)
+        logConditionalPrior += _psiExperimentObject._distributions[_psiProblem->_conditionalPriorIndexes[k]]->getLogDensity(_subProblemSampleCoordinates[j][k]);
 
-      logValues[j] = logConditionalPrior - _thetaProblemSampleLogPriors[j];
+      logValues[j] = logConditionalPrior - _subProblemSampleLogPriors[j];
     }
 
-    double localSum = -log(_thetaProblemSampleCount) + logSumExp(logValues);
+    double localSum = -log(_subProblemSampleCount) + logSumExp(logValues);
 
     _precomputedLogDenominator.push_back(localSum);
   }
@@ -90,6 +94,13 @@ void Theta::initialize()
 
 void Theta::evaluateLogLikelihood(Sample &sample)
 {
+  double logLikelihood = 0.0;
+
+  dynamic_cast<problem::Bayesian*>(_subExperimentObject._problem)->evaluateLoglikelihood(sample);
+
+  std::vector<double> psiSample;
+  psiSample.resize(_psiVariableCount);
+
   std::vector<double> logValues;
   logValues.resize(_psiProblemSampleCount);
 
@@ -101,7 +112,7 @@ void Theta::evaluateLogLikelihood(Sample &sample)
     _psiProblem->updateConditionalPriors(psiSample);
 
     double logConditionalPrior = 0.;
-    for (size_t k = 0; k < _thetaVariableCount; k++)
+    for (size_t k = 0; k < _subProblemVariableCount; k++)
       logConditionalPrior += _psiExperimentObject._distributions[_psiProblem->_conditionalPriorIndexes[k]]->getLogDensity(sample["Parameters"][k]);
 
     logValues[i] = logConditionalPrior - _precomputedLogDenominator[i];
@@ -114,13 +125,13 @@ void Theta::setConfiguration(knlohmann::json& js)
 {
  if (isDefined(js, "Results"))  eraseValue(js, "Results");
 
- if (isDefined(js, "Theta Experiment"))
+ if (isDefined(js, "Sub Experiment"))
  {
- _thetaExperiment = js["Theta Experiment"].get<knlohmann::json>();
+ _subExperiment = js["Sub Experiment"].get<knlohmann::json>();
 
-   eraseValue(js, "Theta Experiment");
+   eraseValue(js, "Sub Experiment");
  }
-  else   KORALI_LOG_ERROR(" + No value provided for mandatory setting: ['Theta Experiment'] required by theta.\n"); 
+  else   KORALI_LOG_ERROR(" + No value provided for mandatory setting: ['Sub Experiment'] required by theta.\n"); 
 
  if (isDefined(js, "Psi Experiment"))
  {
@@ -140,7 +151,7 @@ void Theta::getConfiguration(knlohmann::json& js)
 {
 
  js["Type"] = _type;
-   js["Theta Experiment"] = _thetaExperiment;
+   js["Sub Experiment"] = _subExperiment;
    js["Psi Experiment"] = _psiExperiment;
  Hierarchical::getConfiguration(js);
 } 

--- a/source/modules/problem/hierarchical/theta/theta.cpp.base
+++ b/source/modules/problem/hierarchical/theta/theta.cpp.base
@@ -6,25 +6,21 @@ __startNamespace__;
 
 void __className__::initialize()
 {
+
+  // Psi Experiment
+
   // Setting experiment configurations to actual korali experiments
   _psiExperimentObject._js.getJson() = _psiExperiment;
-  _thetaExperimentObject._js.getJson() = _thetaExperiment;
 
   // Running initialization to verify that the configuration is correct
   _psiExperimentObject.initialize();
-  _thetaExperimentObject.initialize();
 
   _psiProblem = dynamic_cast<Psi *>(_psiExperimentObject._problem);
   if (_psiProblem == NULL) KORALI_LOG_ERROR("Psi experiment passed is not of type Hierarchical/Psi\n");
 
-  if (_thetaExperiment["Is Finished"] == false)
-    KORALI_LOG_ERROR("The Hierarchical Bayesian (Theta) requires that the theta problem has run completely, but this one has not.\n");
-
   // Now inheriting Sub problem's variables
-  _k->_distributions = _thetaExperimentObject._distributions;
-  _k->_variables = _thetaExperimentObject._variables;
-
-  _thetaVariableCount = _thetaExperimentObject._variables.size();
+  _k->_distributions = _subExperimentObject._distributions;
+  _k->_variables = _subExperimentObject._variables;
   _psiVariableCount = _psiExperimentObject._variables.size();
 
   // Loading Psi problem results
@@ -40,21 +36,29 @@ void __className__::initialize()
       KORALI_LOG_ERROR("Non finite (%lf) prior has been detected at sample %zu in Psi problem.\n", expPrior, i);
   }
 
-  // Loading Theta problem results
-  _thetaProblemSampleCount = _thetaExperiment["Solver"]["Chain Leaders LogLikelihoods"].size();
-  _thetaProblemSampleLogLikelihoods = _thetaExperiment["Solver"]["Sample LogLikelihood Database"].get<std::vector<double>>();
-  _thetaProblemSampleLogPriors = _thetaExperiment["Solver"]["Sample LogPrior Database"].get<std::vector<double>>();
-  _thetaProblemSampleCoordinates = _thetaExperiment["Solver"]["Sample Database"].get<std::vector<std::vector<double>>>();
+  /// Sub Experiment
+  if (_subExperiment["Is Finished"] == false)
+    KORALI_LOG_ERROR("The Hierarchical Bayesian (Theta) requires that the sub problem has run completely, but this one has not.\n");
 
-  for (size_t i = 0; i < _thetaProblemSampleLogPriors.size(); i++)
+  _subExperimentObject._js.getJson() = _subExperiment;
+  _subExperimentObject.initialize();
+  _subProblemVariableCount = _subExperimentObject._variables.size();
+
+  // Loading Theta problem results
+  _subProblemSampleCount = _subExperiment["Solver"]["Chain Leaders LogLikelihoods"].size();
+  _subProblemSampleLogLikelihoods = _subExperiment["Solver"]["Sample LogLikelihood Database"].get<std::vector<double>>();
+  _subProblemSampleLogPriors = _subExperiment["Solver"]["Sample LogPrior Database"].get<std::vector<double>>();
+  _subProblemSampleCoordinates = _subExperiment["Solver"]["Sample Database"].get<std::vector<std::vector<double>>>();
+
+  for (size_t i = 0; i < _subProblemSampleLogPriors.size(); i++)
   {
-    double expPrior = exp(_thetaProblemSampleLogPriors[i]);
+    double expPrior = exp(_subProblemSampleLogPriors[i]);
     if (std::isfinite(expPrior) == false)
-      KORALI_LOG_ERROR("Non finite (%lf) prior has been detected at sample %zu in Theta problem.\n", expPrior, i);
+      KORALI_LOG_ERROR("Non finite (%lf) prior has been detected at sample %zu in sub problem.\n", expPrior, i);
   }
 
   std::vector<double> logValues;
-  logValues.resize(_thetaProblemSampleCount);
+  logValues.resize(_subProblemSampleCount);
 
   _psiProblem = dynamic_cast<Psi *>(_psiProblem);
 
@@ -65,16 +69,16 @@ void __className__::initialize()
 
     _psiProblem->updateConditionalPriors(psiSample);
 
-    for (size_t j = 0; j < _thetaProblemSampleCount; j++)
+    for (size_t j = 0; j < _subProblemSampleCount; j++)
     {
       double logConditionalPrior = 0;
-      for (size_t k = 0; k < _thetaVariableCount; k++)
-        logConditionalPrior += _psiExperimentObject._distributions[_psiProblem->_conditionalPriorIndexes[k]]->getLogDensity(_thetaProblemSampleCoordinates[j][k]);
+      for (size_t k = 0; k < _subProblemVariableCount; k++)
+        logConditionalPrior += _psiExperimentObject._distributions[_psiProblem->_conditionalPriorIndexes[k]]->getLogDensity(_subProblemSampleCoordinates[j][k]);
 
-      logValues[j] = logConditionalPrior - _thetaProblemSampleLogPriors[j];
+      logValues[j] = logConditionalPrior - _subProblemSampleLogPriors[j];
     }
 
-    double localSum = -log(_thetaProblemSampleCount) + logSumExp(logValues);
+    double localSum = -log(_subProblemSampleCount) + logSumExp(logValues);
 
     _precomputedLogDenominator.push_back(localSum);
   }
@@ -84,6 +88,13 @@ void __className__::initialize()
 
 void __className__::evaluateLogLikelihood(Sample &sample)
 {
+  double logLikelihood = 0.0;
+
+  dynamic_cast<problem::Bayesian*>(_subExperimentObject._problem)->evaluateLoglikelihood(sample);
+
+  std::vector<double> psiSample;
+  psiSample.resize(_psiVariableCount);
+
   std::vector<double> logValues;
   logValues.resize(_psiProblemSampleCount);
 
@@ -95,7 +106,7 @@ void __className__::evaluateLogLikelihood(Sample &sample)
     _psiProblem->updateConditionalPriors(psiSample);
 
     double logConditionalPrior = 0.;
-    for (size_t k = 0; k < _thetaVariableCount; k++)
+    for (size_t k = 0; k < _subProblemVariableCount; k++)
       logConditionalPrior += _psiExperimentObject._distributions[_psiProblem->_conditionalPriorIndexes[k]]->getLogDensity(sample["Parameters"][k]);
 
     logValues[i] = logConditionalPrior - _precomputedLogDenominator[i];

--- a/source/modules/problem/hierarchical/theta/theta.cpp.base
+++ b/source/modules/problem/hierarchical/theta/theta.cpp.base
@@ -83,6 +83,15 @@ void __className__::initialize()
     _precomputedLogDenominator.push_back(localSum);
   }
 
+  // Now inheriting Sub problem's variables and distributions
+  _k->_variables.clear();
+  for (size_t i = 0; i < _subExperimentObject._variables.size(); i++)
+   _k->_variables.push_back(_subExperimentObject._variables[i]);
+
+  _k->_distributions.clear();
+  for (size_t i = 0; i < _subExperimentObject._distributions.size(); i++)
+    _k->_distributions.push_back(_subExperimentObject._distributions[i]);
+
   Hierarchical::initialize();
 }
 

--- a/source/modules/problem/hierarchical/theta/theta.hpp
+++ b/source/modules/problem/hierarchical/theta/theta.hpp
@@ -108,6 +108,10 @@ class Theta : public Hierarchical
   * @brief Results from the hierarchical problem (Psi).
   */
    knlohmann::json _psiExperiment;
+  /**
+  * @brief Stores the a function used by the underlying Bayesian problem, if required.
+  */
+   std::uint64_t _subExperimentModel;
   
  
   /**

--- a/source/modules/problem/hierarchical/theta/theta.hpp
+++ b/source/modules/problem/hierarchical/theta/theta.hpp
@@ -37,7 +37,7 @@ class Theta : public Hierarchical
   /**
   * @brief Stores the actual Korali object for the theta experiment
   */
-  korali::Experiment _thetaExperimentObject;
+  korali::Experiment _subExperimentObject;
 
   /**
   * @brief Stores the number of variables defined in the Psi problem
@@ -70,29 +70,29 @@ class Theta : public Hierarchical
   korali::problem::hierarchical::Psi *_psiProblem;
 
   /**
-  * @brief Stores the number of variables defined in the Psi problem
+  * @brief Stores the number of variables defined in the Sub problem
   */
-  size_t _thetaVariableCount;
+  size_t _subProblemVariableCount;
 
   /**
-  * @brief Stores the number of samples in the Psi problem experiment to use as input
+  * @brief Stores the number of samples in the sub problem experiment to use as input
   */
-  size_t _thetaProblemSampleCount;
+  size_t _subProblemSampleCount;
 
   /**
-  * @brief Stores the sample coordinates of the Psi Problem
+  * @brief Stores the sample coordinates of the sub Problem
   */
-  std::vector<std::vector<double>> _thetaProblemSampleCoordinates;
+  std::vector<std::vector<double>> _subProblemSampleCoordinates;
 
   /**
- * @brief Stores the sample logLikelihoods of the Psi Problem
+ * @brief Stores the sample logLikelihoods of the sub Problem
  */
-  std::vector<double> _thetaProblemSampleLogLikelihoods;
+  std::vector<double> _subProblemSampleLogLikelihoods;
 
   /**
-  * @brief Stores the sample logPriors of the Psi Problem
+  * @brief Stores the sample logPriors of the sub Problem
   */
-  std::vector<double> _thetaProblemSampleLogPriors;
+  std::vector<double> _subProblemSampleLogPriors;
 
   /**
   * @brief Stores the precomputed log denomitator to speed up calculations
@@ -101,9 +101,9 @@ class Theta : public Hierarchical
 
   public: 
   /**
-  * @brief Results from one previous Korali execution.
+  * @brief Results from one previously executed Bayesian experiment.
   */
-   knlohmann::json _thetaExperiment;
+   knlohmann::json _subExperiment;
   /**
   * @brief Results from the hierarchical problem (Psi).
   */

--- a/source/modules/problem/hierarchical/theta/theta.hpp.base
+++ b/source/modules/problem/hierarchical/theta/theta.hpp.base
@@ -16,7 +16,7 @@ class __className__ : public __parentClassName__
   /**
   * @brief Stores the actual Korali object for the theta experiment
   */
-  korali::Experiment _thetaExperimentObject;
+  korali::Experiment _subExperimentObject;
 
   /**
   * @brief Stores the number of variables defined in the Psi problem
@@ -49,29 +49,29 @@ class __className__ : public __parentClassName__
   korali::problem::hierarchical::Psi *_psiProblem;
 
   /**
-  * @brief Stores the number of variables defined in the Psi problem
+  * @brief Stores the number of variables defined in the Sub problem
   */
-  size_t _thetaVariableCount;
+  size_t _subProblemVariableCount;
 
   /**
-  * @brief Stores the number of samples in the Psi problem experiment to use as input
+  * @brief Stores the number of samples in the sub problem experiment to use as input
   */
-  size_t _thetaProblemSampleCount;
+  size_t _subProblemSampleCount;
 
   /**
-  * @brief Stores the sample coordinates of the Psi Problem
+  * @brief Stores the sample coordinates of the sub Problem
   */
-  std::vector<std::vector<double>> _thetaProblemSampleCoordinates;
+  std::vector<std::vector<double>> _subProblemSampleCoordinates;
 
   /**
- * @brief Stores the sample logLikelihoods of the Psi Problem
+ * @brief Stores the sample logLikelihoods of the sub Problem
  */
-  std::vector<double> _thetaProblemSampleLogLikelihoods;
+  std::vector<double> _subProblemSampleLogLikelihoods;
 
   /**
-  * @brief Stores the sample logPriors of the Psi Problem
+  * @brief Stores the sample logPriors of the sub Problem
   */
-  std::vector<double> _thetaProblemSampleLogPriors;
+  std::vector<double> _subProblemSampleLogPriors;
 
   /**
   * @brief Stores the precomputed log denomitator to speed up calculations

--- a/source/modules/solver/agent/agent.cpp
+++ b/source/modules/solver/agent/agent.cpp
@@ -108,15 +108,15 @@ void Agent::initialize()
     _rewardRescalingSigma = 1.0f;
     _rewardRescalingCount = 0;
     _rewardOutboundPenalizationCount = 0;
+
+    // Getting agent's initial policy
+    _trainingCurrentPolicy = getAgentPolicy();
   }
 
   // If this continues a previous training run, deserialize previous input experience replay
   if (_k->_currentGeneration > 0)
     if (_mode == "Training" || _testingBestPolicy.empty())
       deserializeExperienceReplay();
-
-  // Getting agent's initial policy
-  _trainingCurrentPolicy = getAgentPolicy();
 
   // Initializing session-wise profiling timers
   _sessionRunningTime = 0.0;
@@ -181,6 +181,9 @@ void Agent::runGeneration()
 void Agent::trainingGeneration()
 {
   auto beginTime = std::chrono::steady_clock::now(); // Profiling
+
+  // Setting to the latest saved training policy
+  setAgentPolicy(_trainingCurrentPolicy);
 
   // Setting generation-specific timers
   _generationRunningTime = 0.0;

--- a/source/modules/solver/agent/agent.cpp.base
+++ b/source/modules/solver/agent/agent.cpp.base
@@ -104,15 +104,15 @@ void __className__::initialize()
     _rewardRescalingSigma = 1.0f;
     _rewardRescalingCount = 0;
     _rewardOutboundPenalizationCount = 0;
+
+    // Getting agent's initial policy
+    _trainingCurrentPolicy = getAgentPolicy();
   }
 
   // If this continues a previous training run, deserialize previous input experience replay
   if (_k->_currentGeneration > 0)
     if (_mode == "Training" || _testingBestPolicy.empty())
       deserializeExperienceReplay();
-
-  // Getting agent's initial policy
-  _trainingCurrentPolicy = getAgentPolicy();
 
   // Initializing session-wise profiling timers
   _sessionRunningTime = 0.0;
@@ -177,6 +177,9 @@ void __className__::runGeneration()
 void __className__::trainingGeneration()
 {
   auto beginTime = std::chrono::steady_clock::now(); // Profiling
+
+  // Setting to the latest saved training policy
+  setAgentPolicy(_trainingCurrentPolicy);
 
   // Setting generation-specific timers
   _generationRunningTime = 0.0;

--- a/tests/unit/modules/problems.cpp
+++ b/tests/unit/modules/problems.cpp
@@ -1713,33 +1713,33 @@ namespace
   psiExp["Solver"]["Sample LogLikelihood Database"] = std::vector<double>({0.1});
   psiExp["Solver"]["Chain Leaders LogLikelihoods"] = std::vector<double>({0.1});
 
-  knlohmann::json thetaExp;
-  thetaExp["Is Finished"] = true;
-  thetaExp["Problem"]["Type"] = "Bayesian/Reference";
-  thetaExp["Problem"]["Reference Data"] = std::vector<double>({0.0});
-  thetaExp["Problem"]["Likelihood Model"] = "Normal";
-  thetaExp["Problem"]["Computational Model"] = 0;
-  thetaExp["Variables"][0]["Name"] = "Var X";
-  thetaExp["Variables"][0]["Prior Distribution"] = "Uniform";
-  thetaExp["Distributions"][0]["Name"] = "Uniform";
-  thetaExp["Distributions"][0]["Type"] = "Univariate/Uniform";
-  thetaExp["Distributions"][0]["Minimum"] = 0.0;
-  thetaExp["Distributions"][0]["Maximum"] = 1.0;
-  thetaExp["Solver"]["Type"] = "Sampler/TMCMC";
-  thetaExp["Solver"]["Population Size"] = 1000;
-  thetaExp["Solver"]["Default Burn In"] = 3;
-  thetaExp["Solver"]["Target Coefficient Of Variation"] = 0.6;
-  thetaExp["Solver"]["Covariance Scaling"] = 0.01;
-  thetaExp["Solver"]["Sample Database"] = std::vector<std::vector<double>>({{0.1}});
-  thetaExp["Solver"]["Sample LogPrior Database"] = std::vector<double>({0.1});
-  thetaExp["Solver"]["Sample LogLikelihood Database"] = std::vector<double>({0.1});
-  thetaExp["Solver"]["Chain Leaders LogLikelihoods"] = std::vector<double>({0.1});
+  knlohmann::json subExp;
+  subExp["Is Finished"] = true;
+  subExp["Problem"]["Type"] = "Bayesian/Reference";
+  subExp["Problem"]["Reference Data"] = std::vector<double>({0.0});
+  subExp["Problem"]["Likelihood Model"] = "Normal";
+  subExp["Problem"]["Computational Model"] = 0;
+  subExp["Variables"][0]["Name"] = "Var X";
+  subExp["Variables"][0]["Prior Distribution"] = "Uniform";
+  subExp["Distributions"][0]["Name"] = "Uniform";
+  subExp["Distributions"][0]["Type"] = "Univariate/Uniform";
+  subExp["Distributions"][0]["Minimum"] = 0.0;
+  subExp["Distributions"][0]["Maximum"] = 1.0;
+  subExp["Solver"]["Type"] = "Sampler/TMCMC";
+  subExp["Solver"]["Population Size"] = 1000;
+  subExp["Solver"]["Default Burn In"] = 3;
+  subExp["Solver"]["Target Coefficient Of Variation"] = 0.6;
+  subExp["Solver"]["Covariance Scaling"] = 0.01;
+  subExp["Solver"]["Sample Database"] = std::vector<std::vector<double>>({{0.1}});
+  subExp["Solver"]["Sample LogPrior Database"] = std::vector<double>({0.1});
+  subExp["Solver"]["Sample LogLikelihood Database"] = std::vector<double>({0.1});
+  subExp["Solver"]["Chain Leaders LogLikelihoods"] = std::vector<double>({0.1});
 
   // Configuring Problem
   Theta* pObj;
   knlohmann::json problemJs;
   problemJs["Type"] = "Hierarchical/Theta";
-  problemJs["Theta Experiment"] = thetaExp;
+  problemJs["Theta Experiment"] = subExp;
   problemJs["Psi Experiment"] = psiExp;
 
   ASSERT_NO_THROW(pObj = dynamic_cast<Theta *>(Module::getModule(problemJs, &e)));
@@ -1770,7 +1770,7 @@ namespace
 
   // Testing initialization
   pObj->_psiExperiment = psiExp;
-  pObj->_thetaExperiment = thetaExp;
+  pObj->_subExperiment = subExp;
   ASSERT_NO_THROW(pObj->initialize());
 
   knlohmann::json optExp;
@@ -1782,7 +1782,7 @@ namespace
   optExp["Solver"]["Type"] = "Optimizer/CMAES";
   optExp["Solver"]["Population Size"] = 16;
   pObj->_psiExperiment = optExp;
-  pObj->_thetaExperiment = thetaExp;
+  pObj->_subExperiment = subExp;
   ASSERT_ANY_THROW(pObj->initialize());
 
   optExp["Variables"][0]["Name"] = "Var 1";
@@ -1793,47 +1793,47 @@ namespace
   optExp["Solver"]["Type"] = "Optimizer/CMAES";
   optExp["Solver"]["Population Size"] = 16;
   pObj->_psiExperiment = psiExp;
-  pObj->_thetaExperiment = optExp;
+  pObj->_subExperiment = optExp;
   ASSERT_ANY_THROW(pObj->initialize());
 
   pObj->_psiExperiment = psiExp;
-  pObj->_thetaExperiment = thetaExp;
+  pObj->_subExperiment = subExp;
   pObj->_psiExperiment["Problem"]["Conditional Priors"] = std::vector<std::string>({"Uniform", "Uniform"});
   ASSERT_ANY_THROW(pObj->initialize());
 
   pObj->_psiExperiment = psiExp;
-  pObj->_thetaExperiment = thetaExp;
-  pObj->_thetaExperiment["Is Finished"] = false;
+  pObj->_subExperiment = subExp;
+  pObj->_subExperiment["Is Finished"] = false;
   ASSERT_ANY_THROW(pObj->initialize());
 
   pObj->_psiExperiment = psiExp;
-  pObj->_thetaExperiment = thetaExp;
+  pObj->_subExperiment = subExp;
   pObj->_psiExperiment["Problem"]["Type"] = "Sampling";
   ASSERT_ANY_THROW(pObj->initialize());
 
   pObj->_psiExperiment = psiExp;
-  pObj->_thetaExperiment = thetaExp;
+  pObj->_subExperiment = subExp;
   pObj->_psiExperiment["Problem"]["Conditional Priors"] = std::vector<double>({});
   ASSERT_ANY_THROW(pObj->initialize());
 
   pObj->_psiExperiment = psiExp;
-  pObj->_thetaExperiment = thetaExp;
+  pObj->_subExperiment = subExp;
   pObj->_psiExperiment["Solver"]["Sample LogPrior Database"] = std::vector<double>({std::numeric_limits<double>::infinity()});
   ASSERT_ANY_THROW(pObj->initialize());
 
   pObj->_psiExperiment = psiExp;
-  pObj->_thetaExperiment = thetaExp;
-  pObj->_thetaExperiment["Solver"]["Sample LogPrior Database"] = std::vector<double>({std::numeric_limits<double>::infinity()});
+  pObj->_subExperiment = subExp;
+  pObj->_subExperiment["Solver"]["Sample LogPrior Database"] = std::vector<double>({std::numeric_limits<double>::infinity()});
   ASSERT_ANY_THROW(pObj->initialize());
 
   problemJs = baseProbJs;
   experimentJs = baseExpJs;
-  problemJs.erase("Theta Experiment");
+  problemJs.erase("Sub Experiment");
   ASSERT_ANY_THROW(pObj->setConfiguration(problemJs));
 
   problemJs = baseProbJs;
   experimentJs = baseExpJs;
-  problemJs["Theta Experiment"] = std::vector<knlohmann::json>();
+  problemJs["Sub Experiment"] = std::vector<knlohmann::json>();
   ASSERT_NO_THROW(pObj->setConfiguration(problemJs));
 
   problemJs = baseProbJs;


### PR DESCRIPTION
Fixing restart on RL experiments so that they continue learning with the trained policy and not a fresh one. Also should fix the 'Testing' aspect when no policy is given