### PR TITLE
add one more echo command to test CI on CSCS from a PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,6 +115,7 @@ run_mpi_test_gpu:
   image: art.cscs.ch/contbuild/testing/anfink/${PERSIST_IMAGE_NAME_GPU}
   script:
     - echo "Hello from korali test in Sarus container on node ${SLURMD_NODENAME} (node ID ${SLURM_NODEID}, proc ID ${SLURM_PROCID}, replacing MPI ${USE_MPI})"
+    - echo "This is the modified version from this PR"
     - cd /home/ubuntu/korali/examples/features/running.mpi.cxx && ./run-cmaes 4
   variables:
     SLURM_JOB_NUM_NODES: 2


### PR DESCRIPTION
This PR is here to test CI at CSCS. Writing the comment `cscs-ci run` will trigger the CI. Of course you can add more commits to it, and write again the comment `cscs-ci run` which will trigger again for the latest commit of this PR.
I'm not requesting to merge the PR in the end, it should probably be declined after testing is succesful.