### PR TITLE
Add missing #include <cstdint> directive

### DIFF
--- a/source/auxiliar/math.hpp
+++ b/source/auxiliar/math.hpp
@@ -16,6 +16,7 @@
 #define KORALI_EPSILON 0.00000000001
 
 #include <cmath>
+#include <cstdint>
 #include <gsl/gsl_sf.h>
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_rng.h>


### PR DESCRIPTION
This is required for GCC 13, since standard library includes have been reorganized and it is no longer indirectly/implicitly included.

Fixes errors like:

```
In file included from ../source/auxiliar/math.cpp:1:
../source/auxiliar/math.hpp:39:9: error: ‘uint8_t’ does not name a type   
   39 | typedef uint8_t crc;
      |         ^~~~~~~
../source/auxiliar/math.hpp:30:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdi
nt>’?
   29 | #include <vector>
  +++ |+#include <cstdint>
   30 |
```